### PR TITLE
[#17] 온보딩 추가 로직 구현

### DIFF
--- a/app/src/main/java/com/depromeet/team6/data/dataremote/datasource/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/depromeet/team6/data/dataremote/datasource/AuthRemoteDataSource.kt
@@ -20,8 +20,8 @@ class AuthRemoteDataSource @Inject constructor(
     suspend fun getLogin(provider: Int): Result<ResponseAuthDto> =
         authService.getLogin(provider).toResult()
 
-    suspend fun postLogout(): Result<Unit> =
-        authService.postLogout().toResult()
+    suspend fun postLogout(): Response<Unit> =
+        authService.postLogout()
 
     suspend fun deleteWithDraw(): Response<Unit> =
         authService.deleteWithDraw()

--- a/app/src/main/java/com/depromeet/team6/data/dataremote/service/AuthService.kt
+++ b/app/src/main/java/com/depromeet/team6/data/dataremote/service/AuthService.kt
@@ -37,7 +37,7 @@ interface AuthService {
     ): ApiResponse<ResponseAuthDto>
 
     @POST("$API/$AUTH/$LOGOUT")
-    suspend fun postLogout(): ApiResponse<Unit>
+    suspend fun postLogout(): Response<Unit>
 
     @DELETE("$API/$MEMBERS/$ME")
     suspend fun deleteWithDraw(): Response<Unit>

--- a/app/src/main/java/com/depromeet/team6/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/depromeet/team6/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -20,7 +20,7 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun getLogin(provider: Int): Result<Auth> =
         authRemoteDataSource.getLogin(provider = provider).mapCatching { it.toDomain() }
 
-    override suspend fun postLogout(): Result<Unit> =
+    override suspend fun postLogout(): Response<Unit> =
         authRemoteDataSource.postLogout()
 
     override suspend fun deleteWithDraw(): Response<Unit> =

--- a/app/src/main/java/com/depromeet/team6/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/depromeet/team6/domain/repository/AuthRepository.kt
@@ -11,7 +11,7 @@ interface AuthRepository {
 
     suspend fun getLogin(provider: Int): Result<Auth>
 
-    suspend fun postLogout(): Result<Unit>
+    suspend fun postLogout(): Response<Unit>
 
     suspend fun deleteWithDraw(): Response<Unit>
 }

--- a/app/src/main/java/com/depromeet/team6/domain/usecase/PostLogoutUseCase.kt
+++ b/app/src/main/java/com/depromeet/team6/domain/usecase/PostLogoutUseCase.kt
@@ -1,6 +1,7 @@
 package com.depromeet.team6.domain.usecase
 
 import com.depromeet.team6.domain.repository.AuthRepository
+import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -8,6 +9,6 @@ import javax.inject.Singleton
 class PostLogoutUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(): Result<Unit> =
+    suspend operator fun invoke(): Response<Unit> =
         authRepository.postLogout()
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeContract.kt
@@ -10,7 +10,8 @@ class HomeContract {
         val loadState: LoadState = LoadState.Idle,
         val isAlarmRegistered: Boolean = false,
         val isBusDeparted: Boolean = false,
-        val showSpeechBubble: Boolean = true
+        val showSpeechBubble: Boolean = true,
+        val logoutState: Boolean = false
     ) : UiState
 
     sealed interface HomeSideEffect : UiSideEffect {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.depromeet.team6.presentation.ui.home
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.data.repositoryimpl.UserInfoRepositoryImpl
 import com.depromeet.team6.domain.usecase.DeleteWithDrawUseCase
@@ -32,8 +33,8 @@ class HomeViewModel @Inject constructor(
     override suspend fun handleEvent(event: HomeContract.HomeEvent) {
         when (event) {
             is HomeContract.HomeEvent.DummyEvent -> setState { copy(loadState = event.loadState) }
-            is HomeContract.HomeEvent.LogoutClicked -> logout()
-            is HomeContract.HomeEvent.WithDrawClicked -> withDraw()
+            is HomeContract.HomeEvent.LogoutClicked -> setState { copy(loadState = event.loadState) }
+            is HomeContract.HomeEvent.WithDrawClicked -> setState { copy(loadState = event.loadState) }
             is HomeContract.HomeEvent.UpdateAlarmRegistered -> setState { copy(isAlarmRegistered = event.isRegistered) }
             is HomeContract.HomeEvent.UpdateBusDeparted -> setState { copy(isBusDeparted = event.isBusDeparted) }
             is HomeContract.HomeEvent.UpdateSpeechBubbleVisibility -> setState { copy(showSpeechBubble = event.show) }
@@ -68,12 +69,13 @@ class HomeViewModel @Inject constructor(
     }
 
     fun logout() {
+        Log.d("Logout Reponse", "Logout Response: $postLogoutUseCase")
+        userInfoRepositoryImpl.setAccessToken(userInfoRepositoryImpl.getRefreshToken())
         viewModelScope.launch {
-            postLogoutUseCase().onSuccess {
+            if (postLogoutUseCase().isSuccessful) {
                 setEvent(HomeContract.HomeEvent.LogoutClicked(loadState = LoadState.Error))
                 userInfoRepositoryImpl.clear()
-                setState { copy(loadState = LoadState.Error) }
-            }.onFailure {
+            } else {
                 setEvent(HomeContract.HomeEvent.LogoutClicked(loadState = LoadState.Idle))
             }
         }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/login/LoginScreen.kt
@@ -137,7 +137,6 @@ fun LoginScreen(
             imageVector = ImageVector.vectorResource(R.drawable.ic_login_logo),
             contentDescription = null,
             tint = Color.Unspecified,
-            modifier = Modifier.padding(start = 34.dp)
         )
         Spacer(modifier = Modifier.weight(1f))
         Row(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/login/LoginScreen.kt
@@ -136,7 +136,7 @@ fun LoginScreen(
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_login_logo),
             contentDescription = null,
-            tint = Color.Unspecified,
+            tint = Color.Unspecified
         )
         Spacer(modifier = Modifier.weight(1f))
         Row(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
@@ -59,7 +59,9 @@ class MainActivity : ComponentActivity() {
                 val snackbarHostState = remember { SnackbarHostState() }
                 val coroutineScope = rememberCoroutineScope()
 
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                Scaffold(
+                    modifier = Modifier.fillMaxSize()
+                ) { innerPadding ->
                     MainNavHost(
                         navigator = navigator,
                         padding = innerPadding

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -61,20 +61,22 @@ class OnboardingViewModel @Inject constructor(
     private fun handleUpdateSearchText(event: OnboardingContract.OnboardingEvent.UpdateSearchText) {
         setState { copy(searchText = event.text) }
         debounceJob?.cancel()
-        debounceJob = viewModelScope.launch {
-            delay(300)
-            getLocationsUseCase(
-                keyword = event.text,
-                lat = event.lat,
-                lon = event.lon
-            ).onSuccess { locations ->
-                setState {
-                    copy(
-                        searchLocations = locations
-                    )
+        if (event.text.isNotEmpty()) {
+            debounceJob = viewModelScope.launch {
+                delay(300)
+                getLocationsUseCase(
+                    keyword = event.text,
+                    lat = event.lat,
+                    lon = event.lon
+                ).onSuccess { locations ->
+                    setState {
+                        copy(
+                            searchLocations = locations
+                        )
+                    }
+                }.onFailure {
+                    setState { copy(searchLocations = emptyList()) }
                 }
-            }.onFailure {
-                setState { copy(searchLocations = emptyList()) }
             }
         }
     }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/component/OnboardingSearchLocationItem.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/component/OnboardingSearchLocationItem.kt
@@ -8,13 +8,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.depromeet.team6.R
 import com.depromeet.team6.domain.model.Location
 import com.depromeet.team6.presentation.util.modifier.noRippleClickable
 import com.depromeet.team6.presentation.util.modifier.roundedBackgroundWithPadding
@@ -42,12 +47,24 @@ fun OnboardingSearchLocationItem(
             )
             Spacer(modifier = Modifier.height(4.dp))
 
-            Text(
-                text = onboardingSearchLocation.radius + " ' " + onboardingSearchLocation.address,
-                style = defaultTeam6Typography.bodyRegular14,
-                color = defaultTeam6Colors.greySecondaryLabel,
-                overflow = TextOverflow.Ellipsis
-            )
+            Row (verticalAlignment = Alignment.CenterVertically){
+                Text(
+                    text = onboardingSearchLocation.radius,
+                    style = defaultTeam6Typography.bodyRegular14,
+                    color = defaultTeam6Colors.greySecondaryLabel,
+                )
+                Icon(modifier = Modifier.padding(horizontal = 6.dp),
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_all_adrress_devider),
+                    contentDescription = null,
+                    tint = Color.Unspecified
+                )
+                Text(
+                    text = onboardingSearchLocation.address,
+                    style = defaultTeam6Typography.bodyRegular14,
+                    color = defaultTeam6Colors.greySecondaryLabel,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
         Spacer(modifier = Modifier.width(12.dp))
         Text(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/component/OnboardingSearchLocationItem.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/component/OnboardingSearchLocationItem.kt
@@ -47,13 +47,14 @@ fun OnboardingSearchLocationItem(
             )
             Spacer(modifier = Modifier.height(4.dp))
 
-            Row (verticalAlignment = Alignment.CenterVertically){
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = onboardingSearchLocation.radius,
                     style = defaultTeam6Typography.bodyRegular14,
-                    color = defaultTeam6Colors.greySecondaryLabel,
+                    color = defaultTeam6Colors.greySecondaryLabel
                 )
-                Icon(modifier = Modifier.padding(horizontal = 6.dp),
+                Icon(
+                    modifier = Modifier.padding(horizontal = 6.dp),
                     imageVector = ImageVector.vectorResource(R.drawable.ic_all_adrress_devider),
                     contentDescription = null,
                     tint = Color.Unspecified

--- a/app/src/main/java/com/depromeet/team6/presentation/util/context/ContextExt.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/context/ContextExt.kt
@@ -1,0 +1,37 @@
+package com.depromeet.team6.presentation.util.context
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.location.LocationServices
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+suspend fun Context.getUserLocation(): Pair<Double, Double>? {
+    return try {
+        suspendCancellableCoroutine { continuation ->
+            val fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
+
+            fusedLocationClient.lastLocation
+                .addOnSuccessListener { location ->
+                    if (location != null) {
+                        Log.d(
+                            "User_Location",
+                            "Lat: ${location.latitude}, Lon: ${location.longitude}"
+                        )
+                        continuation.resume(Pair(location.latitude, location.longitude))
+                    } else {
+                        Log.d("User_Location", "Failed to get location")
+                        continuation.resume(null) // 위치 정보를 가져오지 못한 경우
+                    }
+                }
+                .addOnFailureListener { exception ->
+                    Log.e("User_Location", "Error fetching location", exception)
+                    continuation.resumeWithException(exception)
+                }
+        }
+    } catch (e: SecurityException) {
+        Log.e("User_Location", "Location permission not granted", e)
+        null
+    }
+}

--- a/app/src/main/res/drawable/ic_all_adrress_devider.xml
+++ b/app/src/main/res/drawable/ic_all_adrress_devider.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="3dp"
+    android:height="4dp"
+    android:viewportWidth="3"
+    android:viewportHeight="4">
+  <path
+      android:pathData="M1.5,2m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"
+      android:fillColor="#666970"/>
+</vector>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #17 

## 📝작업 내용
전반적인 API 연동 테스트를 진행 하였고 로그아웃, 회원탈퇴 Response 타입을 수정하였습니다.
사용자의 위치를 가져오는 함수를 홈에서도 사용하기 때문에 Context확장함수로 빼두었습니다.
현재 마이페이지 UI가 없기 때문에 홈화면 위에 테스트용 로그아웃과 회원탈퇴 버튼을 만들어 두었습니다.

- 회원 정보 등록 유무 API
- 로그인 API
- 회원가입 API
- 로그아웃 API
- 회원탈퇴 API
- 장소 텍스트 검색 API
- 토큰 리이슈 API

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)


https://github.com/user-attachments/assets/6e933803-61fb-43f7-bb9a-746f2705eb89

시연 플로우
1. 카카오 로그인 ->  카카오 토큰으로 Check API 를 통해 회원가입이 되어있는 유저인지 확인
2. 처음이니까 Check API 반환 값 false -> 온보딩으로 이동
3. 로컬에 저장되어있는 위치권한 요청 여부 데이터를 판단해 사용자에게 위치권한 요청
4. 텍스트 장소검색 API 를 통해 집을 등록
5. 알림 시간 등록
6. 온보딩 정보를 통해 SingUp API 호출
7. 로그아웃 API 호출
8. 재로그인시 Check API 에서 true를 반환하므로 login API 를 통해 로그인
9. 회원탈퇴 API 호출
10. 탈퇴했으므로 Check API 에서 false를 반환하여 온보딩으로 이동

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 서버 이슈가 해결되어 온보딩 플로우 시연영상을 추가했습니다