### PR TITLE
[#45] 웹뷰 컴포넌트 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,9 @@ dependencies {
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
+
+    // WebView
+    implementation(libs.accompanist.webview)
 }
 java {
     toolchain {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/common/view/AtChaWebView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/common/view/AtChaWebView.kt
@@ -1,0 +1,50 @@
+package com.depromeet.team6.presentation.ui.common.view
+
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.google.accompanist.web.WebView
+import com.google.accompanist.web.rememberWebViewState
+
+@Composable
+fun AtChaWebView(url: String, onClose: () -> Unit) {
+    val webViewState = rememberWebViewState(url)
+    var webView: android.webkit.WebView? by remember { mutableStateOf(null) }
+
+    BackHandler(enabled = true) {
+        if (webView?.canGoBack() == true) {
+            webView?.goBack()
+        } else {
+            onClose()
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        WebView(
+            state = webViewState,
+            modifier = Modifier.weight(1f),
+            onCreated = { webViewInstance ->
+                with(webViewInstance) {
+                    settings.run {
+                        javaScriptEnabled = true
+                        domStorageEnabled = true
+                        javaScriptCanOpenWindowsAutomatically = false
+                    }
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: android.webkit.WebView?, url: String?) {
+                            super.onPageFinished(view, url)
+                        }
+                    }
+                }
+                webView = webViewInstance
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -11,3 +11,7 @@ object Token {
 object Provider {
     const val KAKAO = 0
 }
+
+object WebViewUrl {
+    const val PRIVACY_POLICY_URL = "https://mammoth-cheese-88e.notion.site/1008a99e3bbe80e88468c11f09c5a2dc?pvs=4"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanistWebview = "0.24.13-rc"
 agp = "8.7.0"
 firebaseBom = "33.10.0"
 kotlin = "2.0.0"
@@ -29,6 +30,7 @@ playServicesMaps = "19.1.0"
 playServicesLocation = "21.3.0"
 
 [libraries]
+accompanist-webview = { module = "com.google.accompanist:accompanist-webview", version.ref = "accompanistWebview" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #45 

## 📝작업 내용

- 개인정보처리방침을 띄우기 위한 웹뷰 컴포넌트를 구현합니다 
- 개인정보처리방침 url 추가

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/492439ac-a955-4670-9e04-7fcc21150804


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 깃허브 서버이슈로 CI 가 안돌아가서 이전 PR닫고 다시올립니다!