### PR TITLE
[#61]2차 MVP에 온보딩 UI 1차 디자인 QA 사항 반영

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
@@ -16,9 +16,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -52,6 +53,7 @@ class MainActivity : ComponentActivity() {
             installSplashScreen()
         }
         WindowCompat.setDecorFitsSystemWindows(window, false)
+
         enableEdgeToEdge()
 
         if (PermissionUtil.alertPermissionCheck(this)) {
@@ -62,6 +64,10 @@ class MainActivity : ComponentActivity() {
             val viewModel: MainViewModel = hiltViewModel()
             val navigator: MainNavigator = rememberMainNavigator()
             val showSplash by viewModel.showSplash.observeAsState(true)
+
+            SideEffect {
+                WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = false
+            }
 
             Team6Theme {
                 LaunchedEffect(Unit) {
@@ -84,11 +90,6 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-
-//    private fun startLockService() {
-//        lockServiceManager.start()
-//        Toast.makeText(this, getString(R.string.lock_service_start_text), Toast.LENGTH_SHORT).show()
-//    }
 
     @Composable
     private fun <T> ObserveEvents(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -308,12 +307,12 @@ fun OnboardingScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .background(color = defaultTeam6Colors.greyWashBackground)
             .padding(padding)
     ) {
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .background(color = defaultTeam6Colors.greyWashBackground)
         ) {
             if (uiState.onboardingType == OnboardingType.HOME) {
                 Spacer(modifier = Modifier.height(72.dp))

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/component/OnboardingSelectLocationButton.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/component/OnboardingSelectLocationButton.kt
@@ -42,7 +42,7 @@ fun OnboardingSelectLocationButton(
             )
             .roundedBackgroundWithPadding(
                 cornerRadius = 8.dp,
-                padding = PaddingValues(vertical = 10.dp)
+                padding = PaddingValues(vertical = 11.dp)
             )
             .noRippleClickable { onClick() },
         verticalAlignment = Alignment.CenterVertically,
@@ -66,7 +66,7 @@ fun OnboardingSelectLocationButton(
                     R.string.onboarding_edit_location_button_current_region
                 }
             ),
-            style = defaultTeam6Typography.bodyRegular13,
+            style = defaultTeam6Typography.bodyRegular14,
             color = defaultTeam6Colors.white
         )
     }

--- a/app/src/main/java/com/depromeet/team6/presentation/util/toast/AtChaToastMessage.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/toast/AtChaToastMessage.kt
@@ -35,12 +35,6 @@ fun atChaToastMessage(
     val yOffsetPx = (yOffsetDp * context.resources.displayMetrics.density).toInt()
     toast.setGravity(Gravity.TOP or Gravity.FILL_HORIZONTAL, 0, yOffsetPx)
 
-//    val slideDown = TranslateAnimation(0f, 0f, -100f, 0f).apply {
-//        duration = 300L
-//        fillAfter = true
-//    }
-//    layout.startAnimation(slideDown)
-
     toast.show()
 
     val toastDurationMs = when (length) {

--- a/app/src/main/java/com/depromeet/team6/presentation/util/toast/AtChaToastMessage.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/toast/AtChaToastMessage.kt
@@ -3,6 +3,7 @@ package com.depromeet.team6.presentation.util.toast
 import android.content.Context
 import android.view.Gravity
 import android.view.LayoutInflater
+import android.view.animation.AlphaAnimation
 import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -12,6 +13,9 @@ import com.depromeet.team6.R
 fun atChaToastMessage(context: Context, @StringRes messageResId: Int, length: Int = Toast.LENGTH_SHORT) {
     val layoutInflater = LayoutInflater.from(context)
     val layout = layoutInflater.inflate(R.layout.atcha_toast, null)
+
+    val animationStartTime = length - 500L
+    val animationDuration = 500L
 
     val textView = layout.findViewById<TextView>(R.id.atcha_toast_Message)
     textView.text = context.getString(messageResId)
@@ -26,6 +30,19 @@ fun atChaToastMessage(context: Context, @StringRes messageResId: Int, length: In
         view = toastContainer
     }
 
-    toast.setGravity(Gravity.TOP or Gravity.FILL_HORIZONTAL, 0, 12)
+    val yOffsetDp = 12 // 원하는 dp 값
+    val yOffsetPx = (yOffsetDp * context.resources.displayMetrics.density).toInt()
+    toast.setGravity(Gravity.TOP or Gravity.FILL_HORIZONTAL, 0, yOffsetPx)
+
+
+    // Fade out 애니메이션
+    val fadeOut = AlphaAnimation(1f, 0f).apply {
+        startOffset = animationStartTime
+        duration = animationDuration
+        fillAfter = true
+    }
+
+    toast.view?.startAnimation(fadeOut)
+
     toast.show()
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/util/toast/AtChaToastMessage.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/toast/AtChaToastMessage.kt
@@ -3,19 +3,20 @@ package com.depromeet.team6.presentation.util.toast
 import android.content.Context
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.view.animation.AlphaAnimation
+import android.view.animation.TranslateAnimation
 import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.StringRes
 import com.depromeet.team6.R
 
-fun atChaToastMessage(context: Context, @StringRes messageResId: Int, length: Int = Toast.LENGTH_SHORT) {
+fun atChaToastMessage(
+    context: Context,
+    @StringRes messageResId: Int,
+    length: Int = Toast.LENGTH_SHORT
+) {
     val layoutInflater = LayoutInflater.from(context)
     val layout = layoutInflater.inflate(R.layout.atcha_toast, null)
-
-    val animationStartTime = length - 500L
-    val animationDuration = 500L
 
     val textView = layout.findViewById<TextView>(R.id.atcha_toast_Message)
     textView.text = context.getString(messageResId)
@@ -30,19 +31,29 @@ fun atChaToastMessage(context: Context, @StringRes messageResId: Int, length: In
         view = toastContainer
     }
 
-    val yOffsetDp = 12 // 원하는 dp 값
+    val yOffsetDp = 12
     val yOffsetPx = (yOffsetDp * context.resources.displayMetrics.density).toInt()
     toast.setGravity(Gravity.TOP or Gravity.FILL_HORIZONTAL, 0, yOffsetPx)
 
-
-    // Fade out 애니메이션
-    val fadeOut = AlphaAnimation(1f, 0f).apply {
-        startOffset = animationStartTime
-        duration = animationDuration
-        fillAfter = true
-    }
-
-    toast.view?.startAnimation(fadeOut)
+//    val slideDown = TranslateAnimation(0f, 0f, -100f, 0f).apply {
+//        duration = 300L
+//        fillAfter = true
+//    }
+//    layout.startAnimation(slideDown)
 
     toast.show()
+
+    val toastDurationMs = when (length) {
+        Toast.LENGTH_SHORT -> 2000L
+        Toast.LENGTH_LONG -> 3500L
+        else -> 2000L
+    }
+
+    layout.postDelayed({
+        val slideUp = TranslateAnimation(0f, 0f, 0f, -layout.height.toFloat()).apply {
+            duration = 500L
+            fillAfter = true
+        }
+        layout.startAnimation(slideUp)
+    }, toastDurationMs - 500L)
 }

--- a/app/src/main/res/layout/atcha_toast.xml
+++ b/app/src/main/res/layout/atcha_toast.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@drawable/bg_atcha_toast_background"
-    android:paddingVertical="8dp"
+    android:elevation="4dp"
     android:paddingHorizontal="16dp"
-    android:elevation="4dp">
+    android:paddingVertical="20dp">
 
     <TextView
         android:id="@+id/atcha_toast_Message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="설정에서 앗차 위치 접근 허용을 항상으로 설정해주세요."
-        android:textSize="14dp"
-        android:textColor="@android:color/white"
         android:fontFamily="@font/pretendard_regular"
+        android:text="설정에서 앗차 위치 접근 허용을 항상으로 설정해주세요."
+        android:textColor="@android:color/white"
         android:textFontWeight="400"
-        app:layout_constraintTop_toTopOf="parent"
+        android:textSize="14dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,6 +2,7 @@
 <resources>
     <style name="Theme.Team6" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
-
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #61

## 📝작업 내용

- 상태 바 투명
- 앱 전반적인 백그라운드가 어두운 계열이라 상태 바 아이콘 흰색으로 변경
- 토스트 메세지 왼쪽 정렬
- 토스트 메세지 사라질 때 위로 슬라이드
- 토스트 메세지 노출 위치 수정
- 현 위치 찾기 버튼 패딩 값, 폰트 수정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/f533689b-4fcd-465e-9200-62fe0b881763


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 아직 2차 업데이트 배포 전이면 이 pr 까지 머지하고 배포 부탁드립니다!