### PR TITLE
[#74] 마이페이지 다이얼로그 연결

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageContract.kt
@@ -9,7 +9,9 @@ class MypageContract {
     data class MypageUiState(
         val loadState: LoadState = LoadState.Idle,
         val logoutState: Boolean = false,
-        val isWebViewOpened: Boolean = false
+        val isWebViewOpened: Boolean = false,
+        val logoutDialogVisible: Boolean = false,
+        val withDrawDialogVisible: Boolean = false
     ) : UiState
 
     sealed interface MypageSideEffect : UiSideEffect {
@@ -18,10 +20,13 @@ class MypageContract {
     }
 
     sealed class MypageEvent : UiEvent {
-        data class LogoutClicked(val loadState: LoadState) : MypageEvent()
-        data class WithDrawClicked(val loadState: LoadState) : MypageEvent()
+        data object LogoutClicked : MypageEvent()
+        data object WithDrawClicked : MypageEvent()
         data object BackPressed : MypageEvent()
         data object PolicyClicked : MypageEvent()
         data object PolicyClosed : MypageEvent()
+        data object LogoutConfirmed : MypageEvent()
+        data object WithDrawConfirmed : MypageEvent()
+        data object DismissDialog : MypageEvent()
     }
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/component/MyPageConfirmDialog.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/component/MyPageConfirmDialog.kt
@@ -14,15 +14,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.depromeet.team6.R
 import com.depromeet.team6.ui.theme.LocalTeam6Colors
 import com.depromeet.team6.ui.theme.LocalTeam6Typography
 
 @Composable
-fun ConfirmDialog(
+fun MyPageConfirmDialog(
     title: String,
+    confirmText: String,
     onDismiss: () -> Unit,
     onSuccess: () -> Unit,
     modifier: Modifier = Modifier
@@ -44,7 +47,7 @@ fun ConfirmDialog(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "${title}하시겠어요?",
+                text = title,
                 color = colors.white,
                 style = typography.heading5Bold17,
                 textAlign = TextAlign.Center,
@@ -68,7 +71,7 @@ fun ConfirmDialog(
                     )
                 ) {
                     Text(
-                        text = "취소",
+                        text = stringResource(R.string.mypage_dialog_cancle),
                         color = colors.white,
                         style = typography.bodyMedium14,
                         modifier = Modifier.padding(vertical = 13.dp)
@@ -86,7 +89,7 @@ fun ConfirmDialog(
                     )
                 ) {
                     Text(
-                        text = title,
+                        text = confirmText,
                         color = colors.black,
                         style = typography.bodyMedium14,
                         modifier = Modifier.padding(vertical = 13.dp)
@@ -99,9 +102,10 @@ fun ConfirmDialog(
 
 @Preview
 @Composable
-fun ConfirmDialogPreview() {
-    ConfirmDialog(
-        title = "로그아웃",
+fun MyPageConfirmDialogPreview() {
+    MyPageConfirmDialog(
+        title = stringResource(R.string.mypage_logout_dialog_title),
+        confirmText = stringResource(R.string.mypage_logout_dialog_confirm),
         onDismiss = {},
         onSuccess = {},
         modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,5 +112,11 @@
     <string name="mypage_account_logout_text">로그아웃</string>
     <string name="mypage_account_signout_text">계정 탈퇴</string>
     <string name="mypage_icon_description">마이페이지 아이콘</string>
+    <string name="mypage_logout_dialog_title">로그아웃하시겠어요?</string>
+    <string name="mypage_withdraw_dialog_title">탈퇴하시겠어요?</string>
+    <string name="mypage_logout_dialog_confirm">로그아웃</string>
+    <string name="mypage_withdraw_dialog_confirm">탈퇴하기</string>
+    <string name="mypage_dialog_cancle">취소</string>
+
 
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #74

## 📝작업 내용

- 로그아웃과 회원탈퇴를 위한 다이얼로그 연결
- sdieEffect로 로그인 화면 이동
- 다이얼로그 외의 영역을 클릭해도 dismissDialog Event 호출

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/3152614e-da13-45ca-bace-e9450cc5e708


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - N/A