### PR TITLE
[#94] 말풍선 색상 원복 및 홈 높이 조정

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -358,7 +358,7 @@ fun HomeScreen(
                     stringResource(R.string.home_bubble_basic_text),
                     "약 " + NumberFormat.getNumberInstance(Locale.US).format(homeUiState.taxiCost) + stringResource(R.string.home_bubble_won_text),
                     null,
-                    209.dp
+                    194.dp
                 )
 
             homeUiState.userDeparture ->

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/CourseDetailButton.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/CourseDetailButton.kt
@@ -42,7 +42,7 @@ fun CourseDetailButton(
             containerColor = colors.systemGrey5,
             contentColor = colors.white
         ),
-        shape = RoundedCornerShape(8.dp)
+        shape = RoundedCornerShape(10.dp)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/DeleteAlarmDialog.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/DeleteAlarmDialog.kt
@@ -2,6 +2,7 @@ package com.depromeet.team6.presentation.ui.home.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -61,6 +62,7 @@ fun DeleteAlarmDialog(
                     modifier = Modifier
                         .weight(1f)
                         .padding(bottom = 28.dp),
+                    contentPadding = PaddingValues(0.dp),
                     shape = RoundedCornerShape(8.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = colors.greyDefaultButton
@@ -79,6 +81,7 @@ fun DeleteAlarmDialog(
                     modifier = Modifier
                         .padding(bottom = 28.dp)
                         .weight(1f),
+                    contentPadding = PaddingValues(0.dp),
                     shape = RoundedCornerShape(8.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = colors.systemGreen

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
@@ -98,7 +98,7 @@ fun TMapViewCompose(
     ) {
         AndroidView(
             modifier = modifier.fillMaxWidth()
-                .height(screenHeight - 210.dp)
+                .height(screenHeight - 200.dp)
                 .align(Alignment.TopCenter),
             factory = { context ->
                 // FrameLayout을 직접 생성

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/SpeechBubble.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/SpeechBubble.kt
@@ -131,7 +131,7 @@ fun SpeechBubble(
     Box(
         modifier = modifier
             .background(
-                color = colors.white,
+                color = colors.greyElevatedBackground,
                 shape = SpeechBubbleShape(tailExist = tailExist)
             ),
         contentAlignment = Alignment.Center

--- a/app/src/main/res/drawable/ic_home_current_location.xml
+++ b/app/src/main/res/drawable/ic_home_current_location.xml
@@ -12,7 +12,4 @@
       android:strokeWidth="3"
       android:fillColor="#1777FF"
       android:strokeColor="#ffffff"/>
-  <path
-      android:pathData="M29.214,48.999C29.614,49.509 30.386,49.509 30.786,48.999L34.229,44.618C34.744,43.962 34.277,43 33.443,43L26.558,43C25.723,43 25.256,43.962 25.771,44.618L29.214,48.999Z"
-      android:fillColor="#ffffff"/>
 </vector>


### PR DESCRIPTION
## #️⃣연관된 이슈

- 

## 📝작업 내용

- 말풍선 색상 흰색으로 변경된거 원복
- 홈 화면 bottom sheet 높이 맞춰서 지도, 캐릭터 높이 조정

## PR 발행 전 체크 리스트

-  [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인
