### PR TITLE
[#94] 네비게이션 바 검정색 색상 전체 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,6 +146,9 @@ dependencies {
 
     // Lottie
     implementation(libs.lottie.compose)
+
+    // SystemUiController
+    implementation(libs.accompanist.systemuicontroller)
 }
 java {
     toolchain {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -54,6 +55,7 @@ import com.depromeet.team6.presentation.util.permission.PermissionUtil
 import com.depromeet.team6.presentation.util.view.LoadState
 import com.depromeet.team6.ui.theme.LocalTeam6Colors
 import com.depromeet.team6.ui.theme.defaultTeam6Colors
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.google.android.gms.maps.model.LatLng
 import com.google.gson.Gson
 import timber.log.Timber
@@ -91,6 +93,14 @@ fun HomeRoute(
             }
         }
     )
+
+    val systemUiController = rememberSystemUiController()
+
+    SideEffect {
+        systemUiController.setStatusBarColor(
+            color = Color.Black
+        )
+    }
 
     LaunchedEffect(Unit) {
         viewModel.loadAlarmAndCourseInfoFromPrefs(context)
@@ -242,6 +252,7 @@ fun HomeScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
+            .background(color = colors.black)
             .padding(padding)
     ) {
         Image(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
@@ -61,6 +61,10 @@ class MainActivity : ComponentActivity() {
 
             SideEffect {
                 WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = false
+
+                WindowCompat.getInsetsController(window, window.decorView).apply {
+                    isAppearanceLightNavigationBars = false
+                }
             }
 
             Team6Theme {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanistSystemuicontroller = "0.30.1"
 accompanistWebview = "0.24.13-rc"
 agp = "8.7.0"
 firebaseBom = "33.10.0"
@@ -41,6 +42,7 @@ timber = "5.0.1"
 runtimeLivedata = "1.7.8"
 
 [libraries]
+accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemuicontroller" }
 accompanist-webview = { module = "com.google.accompanist:accompanist-webview", version.ref = "accompanistWebview" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #94 

## 📝작업 내용

- 전체 네비게이션 바 검정색으로 적용
- 홈화면 statusBar 색상 검정색 적용

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인
