### PR TITLE
[#122] 홈 유저 데이터 트래킹

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -51,6 +51,7 @@ import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
 import com.depromeet.team6.presentation.util.AmplitudeCommon.USER_ID
 import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNG
 import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNT
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_DIRECT
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.depromeet.team6.presentation.util.context.getUserLocation
@@ -208,7 +209,7 @@ fun HomeRoute(
                     eventName = HOME_COURSESEARCH_ENTERED_DIRECT,
                     mapOf(
                         USER_ID to viewModel.getUserId(),
-                        SCREEN_NAME to "온보딩",
+                        SCREEN_NAME to HOME,
                         HOME_COURSESEARCH_ENTERED_DIRECT to 1
                     )
                 )

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -47,8 +47,12 @@ import com.depromeet.team6.presentation.ui.home.component.CharacterLottieSpeechB
 import com.depromeet.team6.presentation.ui.home.component.CurrentLocationSheet
 import com.depromeet.team6.presentation.ui.home.component.DeleteAlarmDialog
 import com.depromeet.team6.presentation.ui.home.component.TMapViewCompose
+import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
+import com.depromeet.team6.presentation.util.AmplitudeCommon.USER_ID
 import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNG
 import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNT
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_DIRECT
+import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.depromeet.team6.presentation.util.context.getUserLocation
 import com.depromeet.team6.presentation.util.modifier.noRippleClickable
 import com.depromeet.team6.presentation.util.permission.PermissionUtil
@@ -198,6 +202,15 @@ fun HomeRoute(
                 navigateToCourseSearch(
                     currentLocationJSON,
                     destinationPointJSON
+                )
+
+                AmplitudeUtils.trackEventWithProperties(
+                    eventName = HOME_COURSESEARCH_ENTERED_DIRECT,
+                    mapOf(
+                        USER_ID to viewModel.getUserId(),
+                        SCREEN_NAME to "온보딩",
+                        HOME_COURSESEARCH_ENTERED_DIRECT to 1
+                    )
                 )
             },
             onFinishClick = {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -53,6 +53,9 @@ import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNG
 import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNT
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_DIRECT
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_WITH_CURRENT_LOCATION
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_WITH_INPUT
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_DESTINATION_CLICKED
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.depromeet.team6.presentation.util.context.getUserLocation
 import com.depromeet.team6.presentation.util.modifier.noRippleClickable
@@ -214,6 +217,16 @@ fun HomeRoute(
                     )
                 )
             },
+            onDestinationClick = {
+                AmplitudeUtils.trackEventWithProperties(
+                    eventName = HOME_DESTINATION_CLICKED,
+                    mapOf(
+                        USER_ID to viewModel.getUserId(),
+                        SCREEN_NAME to HOME,
+                        HOME_DESTINATION_CLICKED to 1
+                    )
+                )
+            },
             onFinishClick = {
                 viewModel.setEvent(HomeContract.HomeEvent.FinishAlarmClicked)
 //                viewModel.finishAlarm(context)
@@ -231,8 +244,18 @@ fun HomeRoute(
                 navigateToSearchLocation(
                     uiState.destinationPoint
                 )
+
+                AmplitudeUtils.trackEventWithProperties(
+                    eventName = HOME_COURSESEARCH_ENTERED_WITH_INPUT,
+                    mapOf(
+                        USER_ID to viewModel.getUserId(),
+                        SCREEN_NAME to HOME,
+                        HOME_COURSESEARCH_ENTERED_WITH_INPUT to 1
+                    )
+                )
             }
         )
+
         LoadState.Error -> navigateToLogin()
 
         else -> Unit
@@ -247,6 +270,7 @@ fun HomeScreen(
     homeUiState: HomeContract.HomeUiState = HomeContract.HomeUiState(),
     onCharacterClick: () -> Unit = {},
     onSearchClick: () -> Unit = {},
+    onDestinationClick: () -> Unit = {},
     onFinishClick: () -> Unit = {},
     onRefreshClick: () -> Unit = {},
     navigateToMypage: () -> Unit = {},
@@ -375,6 +399,7 @@ fun HomeScreen(
                 onSearchClick = {
                     onSearchClick()
                 },
+                onDestinationClick = { onDestinationClick() },
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
@@ -386,7 +411,8 @@ fun HomeScreen(
             !homeUiState.isAlarmRegistered ->
                 SpeechBubbleText(
                     stringResource(R.string.home_bubble_basic_text),
-                    "약 " + NumberFormat.getNumberInstance(Locale.US).format(homeUiState.taxiCost) + stringResource(R.string.home_bubble_won_text),
+                    "약 " + NumberFormat.getNumberInstance(Locale.US)
+                        .format(homeUiState.taxiCost) + stringResource(R.string.home_bubble_won_text),
                     null,
                     194.dp
                 )
@@ -418,7 +444,8 @@ fun HomeScreen(
             else ->
                 SpeechBubbleText(
                     stringResource(R.string.home_bubble_basic_text),
-                    "약 " + NumberFormat.getNumberInstance(Locale.US).format(homeUiState.taxiCost) + stringResource(R.string.home_bubble_won_text),
+                    "약 " + NumberFormat.getNumberInstance(Locale.US)
+                        .format(homeUiState.taxiCost) + stringResource(R.string.home_bubble_won_text),
                     null,
                     209.dp
                 )

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -53,7 +53,6 @@ import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNG
 import com.depromeet.team6.presentation.util.DefaultLntLng.DEFAULT_LNT
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_DIRECT
-import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_WITH_CURRENT_LOCATION
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_WITH_INPUT
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_DESTINATION_CLICKED
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -37,7 +37,7 @@ class HomeViewModel @Inject constructor(
     private val getBusStartedUseCase: GetBusStartedUseCase,
     private val deleteAlarmUseCase: DeleteAlarmUseCase,
     private val userInfoRepository: UserInfoRepository
-    ) : BaseViewModel<HomeContract.HomeUiState, HomeContract.HomeSideEffect, HomeContract.HomeEvent>() {
+) : BaseViewModel<HomeContract.HomeUiState, HomeContract.HomeSideEffect, HomeContract.HomeEvent>() {
     private var speechBubbleJob: Job? = null
     private var busStartedPollingJob: Job? = null
     private var lastRouteId: String = ""

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.depromeet.team6.domain.model.RouteLocation
 import com.depromeet.team6.domain.model.course.CourseInfo
 import com.depromeet.team6.domain.model.course.LegInfo
 import com.depromeet.team6.domain.model.course.TransportType
+import com.depromeet.team6.domain.repository.UserInfoRepository
 import com.depromeet.team6.domain.usecase.DeleteAlarmUseCase
 import com.depromeet.team6.domain.usecase.GetAddressFromCoordinatesUseCase
 import com.depromeet.team6.domain.usecase.GetBusStartedUseCase
@@ -22,6 +23,8 @@ import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -34,8 +37,9 @@ class HomeViewModel @Inject constructor(
     private val getTaxiCostUseCase: GetTaxiCostUseCase,
     val getCourseSearchResultUseCase: GetCourseSearchResultsUseCase,
     private val getBusStartedUseCase: GetBusStartedUseCase,
-    private val deleteAlarmUseCase: DeleteAlarmUseCase
-) : BaseViewModel<HomeContract.HomeUiState, HomeContract.HomeSideEffect, HomeContract.HomeEvent>() {
+    private val deleteAlarmUseCase: DeleteAlarmUseCase,
+    private val userInfoRepository: UserInfoRepository,
+    ) : BaseViewModel<HomeContract.HomeUiState, HomeContract.HomeSideEffect, HomeContract.HomeEvent>() {
     private var speechBubbleJob: Job? = null
     private var busStartedPollingJob: Job? = null
     private var lastRouteId: String = ""
@@ -473,6 +477,10 @@ class HomeViewModel @Inject constructor(
                 setState { copy(destinationState = LoadState.Error) }
             }
         }
+    }
+
+    fun getUserId(): Int {
+        return userInfoRepository.getUserID()
     }
 
     companion object {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/CurrentLocationSheet.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/CurrentLocationSheet.kt
@@ -23,6 +23,7 @@ fun CurrentLocationSheet(
     currentLocation: String,
     destination: String,
     onSearchLocationClick: () -> Unit,
+    onDestinationClick: () -> Unit,
     onSearchClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -59,7 +60,7 @@ fun CurrentLocationSheet(
                 location = destination,
                 textColor = colors.greySecondaryLabel,
                 backgroundColor = colors.greyWashBackground,
-                onClick = {},
+                onClick = { onDestinationClick() },
                 modifier = Modifier
             )
 
@@ -81,6 +82,7 @@ fun CurrentLocationSheetPreview() {
         currentLocation = "중앙빌딩",
         destination = "우리집",
         onSearchLocationClick = {},
+        onDestinationClick = {},
         onSearchClick = { },
         modifier = Modifier
     )

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/LocationText.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/LocationText.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.depromeet.team6.R
+import com.depromeet.team6.presentation.util.modifier.noRippleClickable
 import com.depromeet.team6.ui.theme.LocalTeam6Colors
 import com.depromeet.team6.ui.theme.LocalTeam6Typography
 
@@ -51,7 +52,7 @@ fun LocationText(
                     shape = RoundedCornerShape(10.dp)
                 )
                 .padding(16.dp)
-                .clickable(onClick = onClick),
+                .noRippleClickable { onClick() },
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/LocationText.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/LocationText.kt
@@ -1,7 +1,6 @@
 package com.depromeet.team6.presentation.ui.home.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
@@ -31,6 +31,12 @@ import androidx.core.graphics.drawable.toBitmap
 import com.depromeet.team6.BuildConfig
 import com.depromeet.team6.R
 import com.depromeet.team6.presentation.ui.home.HomeViewModel
+import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
+import com.depromeet.team6.presentation.util.AmplitudeCommon.USER_ID
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_WITH_CURRENT_LOCATION
+import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG
+import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.google.android.gms.maps.model.LatLng
 import com.skt.tmap.TMapPoint
 import com.skt.tmap.TMapView
@@ -66,6 +72,15 @@ fun TMapViewCompose(
                 val centerLon = tMapView.centerPoint.longitude
 
                 viewModel.getCenterLocation(LatLng(centerLat, centerLon))
+
+                AmplitudeUtils.trackEventWithProperties(
+                    eventName = HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG,
+                    mapOf(
+                        USER_ID to viewModel.getUserId(),
+                        SCREEN_NAME to HOME,
+                        HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG to true
+                    )
+                )
             }
         }
     }
@@ -141,6 +156,15 @@ fun TMapViewCompose(
                     tMapView.setCenterPoint(tMapPoint.latitude, tMapPoint.longitude)
 
                     viewModel.getCenterLocation(LatLng(tMapPoint.latitude, tMapPoint.longitude))
+
+                    AmplitudeUtils.trackEventWithProperties(
+                        eventName = HOME_COURSESEARCH_ENTERED_WITH_CURRENT_LOCATION,
+                        mapOf(
+                            USER_ID to viewModel.getUserId(),
+                            SCREEN_NAME to HOME,
+                            HOME_COURSESEARCH_ENTERED_WITH_CURRENT_LOCATION to true
+                        )
+                    )
                 }
                 .graphicsLayer { alpha = if (isMapReady) 1f else 0.5f } // 비활성화 시 투명도 조정
         )

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -43,4 +43,6 @@ object HomeAmplitude {
     const val HOME_COURSESEARCH_ENTERED_DIRECT = "home_coursesearch_entered_direct"
     const val HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG = "home_coursesearch_entered_with_map_drag"
     const val HOME_COURSESEARCH_ENTERED_WITH_CURRENT_LOCATION = "home_coursesearch_entered_with_current_location"
+    const val HOME_COURSESEARCH_ENTERED_WITH_INPUT = "home_coursesearch_entered_with_input"
+    const val HOME_DESTINATION_CLICKED = "home_destination_clicked"
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -39,5 +39,8 @@ object AmplitudeCommon {
 }
 
 object HomeAmplitude {
+    const val HOME = "홈"
     const val HOME_COURSESEARCH_ENTERED_DIRECT = "home_coursesearch_entered_direct"
+    const val HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG = "home_coursesearch_entered_with_map_drag"
+    const val HOME_COURSESEARCH_ENTERED_WITH_CURRENT_LOCATION = "home_coursesearch_entered_with_current_location"
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -32,3 +32,12 @@ object BusOperationInfo {
     const val HOLIDAY_KR = "공휴일"
     const val UNKNOWN_KR = "알 수 없음"
 }
+
+object AmplitudeCommon {
+    const val SCREEN_NAME = "screen_name"
+    const val USER_ID = "user_id"
+}
+
+object HomeAmplitude {
+    const val HOME_COURSESEARCH_ENTERED_DIRECT = "home_coursesearch_entered_direct"
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #122 

## 📝작업 내용

- 홈에서 경로 검색 진입 방식 비교를 위한 홈, 검색하기, 지도, 현위치, 주소 인풋창 클릭 시 트래킹
- 도착지 영역 클릭 수 트래킹

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)
![스크린샷 2025-04-16 오전 12 10 51](https://github.com/user-attachments/assets/513be662-81e8-4bad-b44a-13c583733ccd)

## 💬리뷰 요구사항(선택)
- 노션에 전달 완료했습니다 ~