### PR TITLE
[#172] 알림 등록 후 홈화면 로직 변경 & 버그 수정

### DIFF
--- a/app/src/main/java/com/depromeet/team6/data/datalocal/datasource/HomeInfoLocalDataSource.kt
+++ b/app/src/main/java/com/depromeet/team6/data/datalocal/datasource/HomeInfoLocalDataSource.kt
@@ -1,0 +1,165 @@
+package com.depromeet.team6.data.datalocal.datasource
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.depromeet.team6.BuildConfig
+import com.depromeet.team6.domain.model.Address
+import com.depromeet.team6.domain.model.course.CourseInfo
+import com.depromeet.team6.presentation.model.bus.BusArrivalParameter
+import com.google.gson.Gson
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class HomeInfoLocalDataSource @Inject constructor(
+    @ApplicationContext context: Context
+){
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+
+    private val gson = Gson()
+
+    var isAlarmRegistered: Boolean
+    get() = getBooleanValue(ALARM_REGISTERED, false)
+    set(value) = setBooleanValue(ALARM_REGISTERED, value)
+
+    var lastRouteId: String
+        get() = getValue(LAST_ROUTE_ID)
+        set(value) = setValue(LAST_ROUTE_ID, value)
+
+    var departurePoint: Address?
+        get() {
+            val json = getValue(DEPARTURE_POINT)
+            return if (json.isNotEmpty()) {
+                try {
+                    gson.fromJson(json, Address::class.java)
+                } catch (e: Exception) {
+                    Timber.e("DeparturePoint 불러오기 실패: ${e.message}")
+                    null
+                }
+            } else {
+                null
+            }
+        }
+        set(value) {
+            val json = if (value != null) {
+                try {
+                    gson.toJson(value)
+                } catch (e: Exception) {
+                    Timber.e("DeparturePoint 저장 실패: ${e.message}")
+                    ""
+                }
+            } else {
+                ""
+            }
+            setValue(DEPARTURE_POINT, json)
+        }
+
+    var lastCourseInfo: CourseInfo?
+        get() {
+            val json = getValue(LAST_COURSE_INFO)
+            return if (json.isNotEmpty()) {
+                try {
+                    gson.fromJson(json, CourseInfo::class.java)
+                } catch (e: Exception) {
+                    Timber.e("CourseInfo 불러오기 실패: ${e.message}")
+                    null
+                }
+            } else {
+                null
+            }
+        }
+        set(value) {
+            val json = if (value != null) {
+                try {
+                    gson.toJson(value)
+                } catch (e: Exception) {
+                    Timber.e("CourseInfo 저장 실패: ${e.message}")
+                    ""
+                }
+            } else {
+                ""
+            }
+            setValue(LAST_COURSE_INFO, json)
+        }
+
+    var userDeparture: Boolean
+        get() = getBooleanValue(USER_DEPARTURE, false)
+        set(value) = setBooleanValue(USER_DEPARTURE, value)
+
+    var destinationPoint: String
+        get() = getValue(DESTINATION_POINT)
+        set(value) = setValue(DESTINATION_POINT, value)
+
+    var busArrivalParameter: BusArrivalParameter?
+        get() {
+            val json = getValue(BUS_ARRIVAL_PARAMETER)
+            return if (json.isNotEmpty()) {
+                try {
+                    gson.fromJson(json, BusArrivalParameter::class.java)
+                } catch (e: Exception) {
+                    Timber.e("BusArrivalParameter 불러오기 실패: ${e.message}")
+                    null
+                }
+            } else {
+                null
+            }
+        }
+        set(value) {
+            val json = if (value != null) {
+                try {
+                    gson.toJson(value)
+                } catch (e: Exception) {
+                    Timber.e("BusArrivalParameter 저장 실패: ${e.message}")
+                    ""
+                }
+            } else {
+                ""
+            }
+            setValue(BUS_ARRIVAL_PARAMETER, json)
+        }
+
+    fun clearAlarmData() {
+        sharedPreferences.edit {
+            remove(DEPARTURE_POINT)
+            remove(LAST_COURSE_INFO)
+            remove(LAST_ROUTE_ID)
+            remove(ALARM_REGISTERED)
+            remove(USER_DEPARTURE)
+            remove(BUS_ARRIVAL_PARAMETER)
+        }
+    }
+
+    fun clearUserDeparture() {
+        setBooleanValue(USER_DEPARTURE, false)
+    }
+
+    private fun getValue(key: String): String =
+        sharedPreferences.getString(key, INITIAL_VALUE).orEmpty()
+
+    private fun setValue(key: String, value: String) =
+        sharedPreferences.edit { putString(key, value) }
+
+    private fun getBooleanValue(key: String, defaultValue: Boolean = false): Boolean =
+        sharedPreferences.getBoolean(key, defaultValue)
+
+    private fun setBooleanValue(key: String, value: Boolean) =
+        sharedPreferences.edit { putBoolean(key, value) }
+
+    companion object {
+        private const val FILE_NAME = "MyPreferences"
+        private const val INITIAL_VALUE = ""
+        private const val ALARM_REGISTERED = "alarmRegistered"
+        private const val LAST_ROUTE_ID = "lastRouteId"
+        private const val DEPARTURE_POINT = "departurePoint"
+        private const val DESTINATION_POINT = "destinationPoint"
+        private const val LAST_COURSE_INFO = "lastCourseInfo"
+        private const val USER_DEPARTURE = "userDeparture"
+        private const val BUS_ARRIVAL_PARAMETER = "busArrivalParameter"
+    }
+}

--- a/app/src/main/java/com/depromeet/team6/data/datalocal/datasource/HomeInfoLocalDataSource.kt
+++ b/app/src/main/java/com/depromeet/team6/data/datalocal/datasource/HomeInfoLocalDataSource.kt
@@ -3,9 +3,6 @@ package com.depromeet.team6.data.datalocal.datasource
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
-import com.depromeet.team6.BuildConfig
 import com.depromeet.team6.domain.model.Address
 import com.depromeet.team6.domain.model.course.CourseInfo
 import com.depromeet.team6.presentation.model.bus.BusArrivalParameter
@@ -18,15 +15,15 @@ import javax.inject.Singleton
 @Singleton
 class HomeInfoLocalDataSource @Inject constructor(
     @ApplicationContext context: Context
-){
+) {
     private val sharedPreferences: SharedPreferences =
         context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
 
     private val gson = Gson()
 
     var isAlarmRegistered: Boolean
-    get() = getBooleanValue(ALARM_REGISTERED, false)
-    set(value) = setBooleanValue(ALARM_REGISTERED, value)
+        get() = getBooleanValue(ALARM_REGISTERED, false)
+        set(value) = setBooleanValue(ALARM_REGISTERED, value)
 
     var lastRouteId: String
         get() = getValue(LAST_ROUTE_ID)

--- a/app/src/main/java/com/depromeet/team6/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/depromeet/team6/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -1,12 +1,67 @@
 package com.depromeet.team6.data.repositoryimpl
 
+import com.depromeet.team6.data.datalocal.datasource.HomeInfoLocalDataSource
 import com.depromeet.team6.data.dataremote.datasource.HomeRemoteDataSource
+import com.depromeet.team6.domain.model.Address
+import com.depromeet.team6.domain.model.course.CourseInfo
 import com.depromeet.team6.domain.repository.HomeRepository
+import com.depromeet.team6.presentation.model.bus.BusArrivalParameter
 import javax.inject.Inject
 
 class HomeRepositoryImpl @Inject constructor(
-    private val homeRepoteDataSource: HomeRemoteDataSource
+    private val homeRemoteDataSource: HomeRemoteDataSource,
+    private val homeInfoLocalDataSource: HomeInfoLocalDataSource
 ) : HomeRepository {
     override suspend fun getBusStarted(lastRouteId: String): Result<Boolean> =
-        homeRepoteDataSource.getBusStarted(lastRouteId = lastRouteId)
+        homeRemoteDataSource.getBusStarted(lastRouteId = lastRouteId)
+
+    override fun setAlarmRegistered(isRegistered: Boolean) {
+        homeInfoLocalDataSource.isAlarmRegistered = isRegistered
+    }
+
+    override fun isAlarmRegistered(): Boolean = homeInfoLocalDataSource.isAlarmRegistered
+
+    override fun setLastRouteId(routeId: String) {
+        homeInfoLocalDataSource.lastRouteId = routeId
+    }
+
+    override fun getLastRouteId(): String = homeInfoLocalDataSource.lastRouteId
+
+    override fun setDeparturePoint(address: Address?) {
+        homeInfoLocalDataSource.departurePoint = address
+    }
+
+    override fun getDeparturePoint(): Address? = homeInfoLocalDataSource.departurePoint
+
+    override fun setDestinationPoint(destinationPoint: String) {
+        homeInfoLocalDataSource.destinationPoint = destinationPoint
+    }
+
+    override fun getDestinationPoint(): String = homeInfoLocalDataSource.destinationPoint
+
+    override fun setLastCourseInfo(courseInfo: CourseInfo?) {
+        homeInfoLocalDataSource.lastCourseInfo = courseInfo
+    }
+
+    override fun getLastCourseInfo(): CourseInfo? = homeInfoLocalDataSource.lastCourseInfo
+
+    override fun setUserDeparture(isDeparted: Boolean) {
+        homeInfoLocalDataSource.userDeparture = isDeparted
+    }
+
+    override fun isUserDeparted(): Boolean = homeInfoLocalDataSource.userDeparture
+
+    override fun setBusArrivalParameter(parameter: BusArrivalParameter?) {
+        homeInfoLocalDataSource.busArrivalParameter = parameter
+    }
+
+    override fun getBusArrivalParameter(): BusArrivalParameter? = homeInfoLocalDataSource.busArrivalParameter
+
+    override fun clearAlarmData() {
+        homeInfoLocalDataSource.clearAlarmData()
+    }
+
+    override fun clearUserDeparture() {
+        homeInfoLocalDataSource.clearUserDeparture()
+    }
 }

--- a/app/src/main/java/com/depromeet/team6/domain/repository/HomeRepository.kt
+++ b/app/src/main/java/com/depromeet/team6/domain/repository/HomeRepository.kt
@@ -1,5 +1,33 @@
 package com.depromeet.team6.domain.repository
 
+import com.depromeet.team6.domain.model.Address
+import com.depromeet.team6.domain.model.course.CourseInfo
+import com.depromeet.team6.presentation.model.bus.BusArrivalParameter
+
 interface HomeRepository {
     suspend fun getBusStarted(lastRouteId: String): Result<Boolean>
+
+    fun setAlarmRegistered(isRegistered: Boolean)
+    fun isAlarmRegistered(): Boolean
+
+    fun setLastRouteId(routeId: String)
+    fun getLastRouteId(): String
+
+    fun setDeparturePoint(address: Address?)
+    fun getDeparturePoint(): Address?
+
+    fun setDestinationPoint(destinationPoint: String)
+    fun getDestinationPoint(): String
+
+    fun setLastCourseInfo(courseInfo: CourseInfo?)
+    fun getLastCourseInfo(): CourseInfo?
+
+    fun setUserDeparture(isDeparted: Boolean)
+    fun isUserDeparted(): Boolean
+
+    fun setBusArrivalParameter(parameter: BusArrivalParameter?)
+    fun getBusArrivalParameter(): BusArrivalParameter?
+
+    fun clearAlarmData()
+    fun clearUserDeparture()
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchScreen.kt
@@ -150,7 +150,7 @@ fun CourseSearchRoute(
                         val registeredCourse = uiState.courseData.find { it.routeId == routeId }
 
                         if (registeredCourse != null) {
-                            viewModel.saveAlarmData(departurePoint,destinationPoint,routeId)
+                            viewModel.saveAlarmData(departurePoint, destinationPoint, routeId)
                             viewModel.postAlarm(lastRouteId = routeId)
                         } else {
                             atChaToastMessage(context, R.string.course_set_notification_failed_snackbar)

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchScreen.kt
@@ -146,20 +146,11 @@ fun CourseSearchRoute(
                 setNotification = { routeId ->
                     if (uiState.sortType == 1) {
                         // 기존 코드 유지 - sortType이 1일 때 알림 등록
-                        val sharedPreferences = context.getSharedPreferences("MyPreferences", Context.MODE_PRIVATE)
-                        val editor = sharedPreferences.edit()
 
                         val registeredCourse = uiState.courseData.find { it.routeId == routeId }
 
                         if (registeredCourse != null) {
-                            val courseJson = Gson().toJson(registeredCourse)
-                            editor.putString("departurePoint", departurePoint) // 출발지
-                            editor.putString("destinationPoint", destinationPoint) // 도착지
-                            editor.putBoolean("alarmRegistered", true) // 알람 등록 여부
-                            editor.putString("lastRouteId", routeId) // 막차 경로 Id
-                            editor.putString("lastCourseInfo", courseJson) // 막차 경로
-                            editor.apply()
-
+                            viewModel.saveAlarmData(departurePoint,destinationPoint,routeId)
                             viewModel.postAlarm(lastRouteId = routeId)
                         } else {
                             atChaToastMessage(context, R.string.course_set_notification_failed_snackbar)

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchViewModel.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.domain.model.Address
 import com.depromeet.team6.domain.model.RouteLocation
+import com.depromeet.team6.domain.repository.HomeRepository
 import com.depromeet.team6.domain.repository.UserInfoRepository
 import com.depromeet.team6.domain.usecase.GetCourseSearchResultsUseCase
 import com.depromeet.team6.domain.usecase.GetTaxiCostUseCase
@@ -28,6 +29,7 @@ import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -35,6 +37,7 @@ class CourseSearchViewModel @Inject constructor(
     private val loadSearchResult: GetCourseSearchResultsUseCase,
     private val postAlarmUseCase: PostAlarmUseCase,
     private val userInfoRepository: UserInfoRepository,
+    private val homeRepository: HomeRepository,
     private val getTaxiCostUseCase: GetTaxiCostUseCase,
     @ApplicationContext private val context: Context
 ) : BaseViewModel<CourseSearchContract.CourseUiState, CourseSearchContract.CourseSideEffect, CourseSearchContract.CourseEvent>() {
@@ -218,6 +221,25 @@ class CourseSearchViewModel @Inject constructor(
                 }.onFailure { exception ->
                     handleApiException(exception)
                 }
+        }
+    }
+
+    fun saveAlarmData(departurePoint: String, destinationPoint: String, routeId: String) {
+        viewModelScope.launch {
+            try {
+                val departureAddress = Gson().fromJson(departurePoint, Address::class.java)
+                val registeredCourse = uiState.value.courseData.find { it.routeId == routeId }
+
+                if (registeredCourse != null && departureAddress != null) {
+                    homeRepository.setDeparturePoint(departureAddress)
+                    homeRepository.setDestinationPoint(destinationPoint)
+                    homeRepository.setLastCourseInfo(registeredCourse)
+                    homeRepository.setLastRouteId(routeId)
+                    homeRepository.setAlarmRegistered(true)
+                }
+            } catch (e: Exception) {
+                Timber.log("spf에 알림 데이터 저장 실패")
+            }
         }
     }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/coursesearch/CourseSearchViewModel.kt
@@ -238,7 +238,7 @@ class CourseSearchViewModel @Inject constructor(
                     homeRepository.setAlarmRegistered(true)
                 }
             } catch (e: Exception) {
-                Timber.log("spf에 알림 데이터 저장 실패")
+                Timber.e("알림 정보 spf 저장 오류: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeContract.kt
@@ -19,6 +19,8 @@ class HomeContract {
     data class HomeUiState(
         val loadState: LoadState = LoadState.Idle,
         val destinationState: LoadState = LoadState.Idle,
+        val afterRegisterDataLoadState: LoadState = LoadState.Idle,
+        val alarmCheckLoadState: LoadState = LoadState.Idle,
         val isAlarmRegistered: Boolean = false,
         val isBusDeparted: Boolean = false,
         val showSpeechBubble: Boolean = true,

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -580,7 +580,10 @@ fun HomeRoute(
                     }
                 )
 
-                if (uiState.loadState == LoadState.Loading) {
+                if (uiState.loadState == LoadState.Loading ||
+                    uiState.alarmCheckLoadState == LoadState.Loading ||
+                    (uiState.isAlarmRegistered && uiState.afterRegisterDataLoadState == LoadState.Loading)
+                ) {
                     AtChaLoadingView()
                 }
             }
@@ -678,94 +681,103 @@ fun HomeScreen(
             isConfirmed = true
         }
 
-        // 알람 등록 시 Home UI
-        if (homeUiState.isAlarmRegistered) {
-            AfterRegisterSheet(
-                timerFinish = homeUiState.timerFinish,
-                startLocation = homeUiState.departurePointName,
-                isConfirmed = isConfirmed,
-                afterUserDeparted = homeUiState.userDeparture,
-                transportType = homeUiState.firtTransportTation,
-                transportationNumber = homeUiState.firstTransportationNumber,
-                transportationName = homeUiState.firstTransportationName,
-                timeToLeave = formatTimeString(homeUiState.departureTime),
-                boardingTime = homeUiState.boardingTime,
-                homeArrivedTime = homeUiState.homeArrivedTime,
-                destination = stringResource(R.string.home_my_home_text),
-                onCourseTextClick = {
-                    showTempMessage(ComponentType.ROUTE_TEXT_CLICKED)
-                    AmplitudeUtils.trackEventWithProperties(
-                        HOME_ROUTE_CLICKED,
-                        mapOf(
-                            SCREEN_NAME to HOME,
-                            USER_ID to getUserId(),
-                            HOME_ROUTE_CLICKED to 1
+        when {
+            homeUiState.alarmCheckLoadState == LoadState.Loading ||
+                (homeUiState.isAlarmRegistered && homeUiState.afterRegisterDataLoadState == LoadState.Loading) -> {
+            }
+
+            // 알림이 등록된 경우
+            homeUiState.isAlarmRegistered && homeUiState.afterRegisterDataLoadState == LoadState.Success -> {
+                AfterRegisterSheet(
+                    timerFinish = homeUiState.timerFinish,
+                    startLocation = homeUiState.departurePointName,
+                    isConfirmed = isConfirmed,
+                    afterUserDeparted = homeUiState.userDeparture,
+                    transportType = homeUiState.firtTransportTation,
+                    transportationNumber = homeUiState.firstTransportationNumber,
+                    transportationName = homeUiState.firstTransportationName,
+                    timeToLeave = formatTimeString(homeUiState.departureTime),
+                    boardingTime = homeUiState.boardingTime,
+                    homeArrivedTime = homeUiState.homeArrivedTime,
+                    destination = stringResource(R.string.home_my_home_text),
+                    onCourseTextClick = {
+                        showTempMessage(ComponentType.ROUTE_TEXT_CLICKED)
+                        AmplitudeUtils.trackEventWithProperties(
+                            HOME_ROUTE_CLICKED,
+                            mapOf(
+                                SCREEN_NAME to HOME,
+                                USER_ID to getUserId(),
+                                HOME_ROUTE_CLICKED to 1
+                            )
                         )
-                    )
-                },
-                deleteAlarmConfirmed = deleteAlarmConfirmed,
-                dismissDialog = dismissDialog,
-                onFinishClick = {
-                    onFinishClick()
-                },
-                onCourseDetailClick = courseDetailBtnClick,
-                onTimerFinished = {
-                    onTimerFinished()
-                },
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .zIndex(1f),
-                onRefreshClick = {
-                    onRefreshClick()
-                    if (homeUiState.firtTransportTation == TransportType.BUS) {
-                        getBusArrival()
-                    }
-                },
-                onIconClick = {
-                    if (homeUiState.isBusDeparted) {
+                    },
+                    deleteAlarmConfirmed = deleteAlarmConfirmed,
+                    dismissDialog = dismissDialog,
+                    onFinishClick = {
+                        onFinishClick()
+                    },
+                    onCourseDetailClick = courseDetailBtnClick,
+                    onTimerFinished = {
+                        onTimerFinished()
+                    },
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .zIndex(1f),
+                    onRefreshClick = {
+                        onRefreshClick()
+                        if (homeUiState.firtTransportTation == TransportType.BUS) {
+                            getBusArrival()
+                        }
+                    },
+                    onIconClick = {
+                        if (homeUiState.isBusDeparted) {
+                            showTempMessage(ComponentType.DEPARTURE_TIME_CONFIRMED_CLICKED)
+                        } else {
+                            showTempMessage(ComponentType.DEPARTURE_TIME_NOT_CONFIRMED_CLICKED)
+                        }
+                    },
+                    onHomeDepartureTimeClick = {
                         showTempMessage(ComponentType.DEPARTURE_TIME_CONFIRMED_CLICKED)
-                    } else {
+                        AmplitudeUtils.trackEventWithProperties(
+                            HOME_DEPARTURE_TIME_CLICKED,
+                            mapOf(
+                                SCREEN_NAME to HOME,
+                                USER_ID to getUserId(),
+                                HOME_DEPARTURE_TIME_CLICKED to 1
+                            )
+                        )
+                    },
+                    onHomeExpectDepartureTimeClick = {
                         showTempMessage(ComponentType.DEPARTURE_TIME_NOT_CONFIRMED_CLICKED)
-                    }
-                },
-                onHomeDepartureTimeClick = {
-                    showTempMessage(ComponentType.DEPARTURE_TIME_CONFIRMED_CLICKED)
-                    AmplitudeUtils.trackEventWithProperties(
-                        HOME_DEPARTURE_TIME_CLICKED,
-                        mapOf(
-                            SCREEN_NAME to HOME,
-                            USER_ID to getUserId(),
-                            HOME_DEPARTURE_TIME_CLICKED to 1
+                        AmplitudeUtils.trackEventWithProperties(
+                            HOME_DEPARTURE_TIME_CLICKED,
+                            mapOf(
+                                SCREEN_NAME to HOME,
+                                USER_ID to getUserId(),
+                                HOME_DEPARTURE_TIME_SUGGESTION_CLICKED to 1
+                            )
                         )
-                    )
-                },
-                onHomeExpectDepartureTimeClick = {
-                    showTempMessage(ComponentType.DEPARTURE_TIME_NOT_CONFIRMED_CLICKED)
-                    AmplitudeUtils.trackEventWithProperties(
-                        HOME_DEPARTURE_TIME_CLICKED,
-                        mapOf(
-                            SCREEN_NAME to HOME,
-                            USER_ID to getUserId(),
-                            HOME_DEPARTURE_TIME_SUGGESTION_CLICKED to 1
-                        )
-                    )
-                },
-                busStationLeft = homeUiState.busRemainingStations
-            )
-        } else {
-            CurrentLocationSheet(
-                currentLocation = homeUiState.markerPoint.name,
-                onSearchLocationClick = navigateToSearchLocation,
-                destination = stringResource(R.string.home_my_home_text),
-                onSearchClick = {
-                    onSearchClick()
-                },
-                onDestinationClick = { onDestinationClick() },
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .zIndex(1f)
-            )
+                    },
+                    busStationLeft = homeUiState.busRemainingStations
+                )
+            }
+
+            // 알림이 등록되지 않은 경우
+            !homeUiState.isAlarmRegistered && homeUiState.alarmCheckLoadState == LoadState.Success -> {
+                CurrentLocationSheet(
+                    currentLocation = homeUiState.markerPoint.name,
+                    onSearchLocationClick = navigateToSearchLocation,
+                    destination = stringResource(R.string.home_my_home_text),
+                    onSearchClick = {
+                        onSearchClick()
+                    },
+                    onDestinationClick = { onDestinationClick() },
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .zIndex(1f)
+                )
+            }
         }
 
         UnifiedCharacterBubble(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -156,8 +156,8 @@ fun HomeRoute(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.loadAlarmAndCourseInfoFromPrefs(context)
-        viewModel.loadUserDepartureState(context)
+        viewModel.loadAlarmAndCourseInfoFromPrefs()
+        viewModel.loadUserDepartureState()
         viewModel.setEvent(HomeContract.HomeEvent.ChangeGreetBottomSheetVisible(afterOnboarding))
     }
 
@@ -167,7 +167,7 @@ fun HomeRoute(
             override fun onResume(owner: LifecycleOwner) {
                 super.onResume(owner)
                 // 화면이 다시 보일 때마다 사용자 출발 상태 로드
-                viewModel.loadUserDepartureState(context)
+                viewModel.loadUserDepartureState()
             }
         }
 
@@ -550,7 +550,7 @@ fun HomeRoute(
                     },
                     deleteAlarmConfirmed = {
                         viewModel.setEvent(HomeContract.HomeEvent.DeleteAlarmConfirmed)
-                        viewModel.deleteAlarm(uiState.lastRouteId, context)
+                        viewModel.deleteAlarm(uiState.lastRouteId)
                     },
                     dismissDialog = {
                         viewModel.setEvent(HomeContract.HomeEvent.DismissDialog)

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -8,6 +8,7 @@ import com.depromeet.team6.domain.model.RouteLocation
 import com.depromeet.team6.domain.model.course.CourseInfo
 import com.depromeet.team6.domain.model.course.LegInfo
 import com.depromeet.team6.domain.model.course.TransportType
+import com.depromeet.team6.domain.repository.HomeRepository
 import com.depromeet.team6.domain.repository.UserInfoRepository
 import com.depromeet.team6.domain.usecase.DeleteAlarmUseCase
 import com.depromeet.team6.domain.usecase.GetAddressFromCoordinatesUseCase
@@ -41,6 +42,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val userInfoRepository: UserInfoRepository,
+    private val homeRepository: HomeRepository,
     private val getAddressFromCoordinatesUseCase: GetAddressFromCoordinatesUseCase,
     private val getUserInfoUseCase: GetUserInfoUseCase,
     private val getTaxiCostUseCase: GetTaxiCostUseCase,
@@ -262,7 +264,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun deleteAlarm(lastRouteId: String, context: Context) {
+    fun deleteAlarm(lastRouteId: String) {
         viewModelScope.launch {
             deleteAlarmUseCase(
                 lastRouteId = lastRouteId
@@ -273,18 +275,7 @@ class HomeViewModel @Inject constructor(
 
                     stopPollingBusStarted()
 
-                    val sharedPreferences = context.getSharedPreferences(
-                        "MyPreferences",
-                        Context.MODE_PRIVATE
-                    )
-                    val editor = sharedPreferences.edit()
-                    editor.remove("departurePoint")
-                    editor.remove("lastCourseInfo")
-                    editor.remove("lastRouteId")
-                    editor.remove("alarmRegistered")
-                    editor.remove("userDeparture")
-
-                    editor.apply()
+                    homeRepository.clearAlarmData()
 
                     setEvent(HomeContract.HomeEvent.DismissDialog)
                     setSideEffect(HomeContract.HomeSideEffect.ShowDeleteAlarmToast)
@@ -385,11 +376,9 @@ class HomeViewModel @Inject constructor(
         busStartedPollingJob = null
     }
 
-    // SharedPreferences에서 사용자 출발 상태를 로드
-    fun loadUserDepartureState(context: Context) {
+    fun loadUserDepartureState() {
         viewModelScope.launch {
-            val sharedPreferences = context.getSharedPreferences(MY_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            val userDeparture = sharedPreferences.getBoolean("userDeparture", false)
+            val userDeparture = homeRepository.isUserDeparted()
             setEvent(HomeContract.HomeEvent.LoadUserDeparture(userDeparture))
             if (currentState.userDeparture && currentState.firtTransportTation == TransportType.BUS) {
                 getBusArrival()
@@ -398,16 +387,15 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun loadAlarmAndCourseInfoFromPrefs(context: Context) {
+    fun loadAlarmAndCourseInfoFromPrefs() {
         viewModelScope.launch {
             setState { copy(alarmCheckLoadState = LoadState.Loading) }
 
-            val prefs = context.getSharedPreferences(MY_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            val isAlarmRegistered = prefs.getBoolean("alarmRegistered", false)
-            val lastRouteId = prefs.getString("lastRouteId", null)
+            val isAlarmRegistered = homeRepository.isAlarmRegistered()
+            val lastRouteId = homeRepository.getLastRouteId()
 
             setEvent(HomeContract.HomeEvent.UpdateAlarmRegistered(isAlarmRegistered))
-            lastRouteId?.let { HomeContract.HomeEvent.UpdateLastRouteId(it) }?.let { setEvent(it) }
+            setEvent(lastRouteId.let { HomeContract.HomeEvent.UpdateLastRouteId(it) })
 
             if (!isAlarmRegistered) {
                 setState {
@@ -425,36 +413,26 @@ class HomeViewModel @Inject constructor(
                 )
             }
 
-            val departurePointJson = prefs.getString("departurePoint", null)
-            departurePointJson?.let {
-                try {
-                    val departurePoint = Gson().fromJson(it, Address::class.java)
-                    setEvent(HomeContract.HomeEvent.UpdateDeparturePointName(departurePoint.name))
-                    setEvent(HomeContract.HomeEvent.UpdateDeparturePoint(departurePoint))
-                } catch (e: Exception) {
-                    Timber.e("DeparturePoint 불러오기 실패: ${e.message}")
-                    e.printStackTrace()
-                }
+            homeRepository.getDeparturePoint()?.let { departurePoint ->
+                setEvent(HomeContract.HomeEvent.UpdateDeparturePointName(departurePoint.name))
+                setEvent(HomeContract.HomeEvent.UpdateDeparturePoint(departurePoint))
             }
-            val courseInfoJson = prefs.getString("lastCourseInfo", null)
-            courseInfoJson?.let {
-                try {
-                    val courseInfo = Gson().fromJson(it, CourseInfo::class.java)
-                    setEvent(HomeContract.HomeEvent.LoadLegsResult(courseInfo))
-                    setEvent(HomeContract.HomeEvent.LoadDepartureDateTime(courseInfo.departureTime))
-                    setEvent(HomeContract.HomeEvent.LoadBoardingDateTime(courseInfo.boardingTime))
-                    setEvent(HomeContract.HomeEvent.LoadHomeArrivedTime(calculateArrivalTime(courseInfo.departureTime, courseInfo.totalTime)))
-                    setEvent(HomeContract.HomeEvent.LoadFirstTransportation(getFirstTransportation(courseInfo.legs)))
-                    setEvent(HomeContract.HomeEvent.LoadFirstTransportationNumber(getFirstTransportationNumber(courseInfo.legs)))
-                    setEvent(HomeContract.HomeEvent.LoadFirstTransportationName(getFirstTransportationName(courseInfo.legs)))
 
-                    if (getFirstTransportation(courseInfo.legs) == TransportType.BUS) {
-                        startPollingBusStarted(lastRouteId!!)
-                    } else if (getFirstTransportation(courseInfo.legs) == TransportType.SUBWAY) {
-                        setEvent(HomeContract.HomeEvent.UpdateBusDeparted(true))
+            homeRepository.getLastCourseInfo()?.let { courseInfo ->
+                setEvent(HomeContract.HomeEvent.LoadLegsResult(courseInfo))
+                setEvent(HomeContract.HomeEvent.LoadDepartureDateTime(courseInfo.departureTime))
+                setEvent(HomeContract.HomeEvent.LoadBoardingDateTime(courseInfo.boardingTime))
+                setEvent(HomeContract.HomeEvent.LoadHomeArrivedTime(calculateArrivalTime(courseInfo.departureTime, courseInfo.totalTime)))
+                setEvent(HomeContract.HomeEvent.LoadFirstTransportation(getFirstTransportation(courseInfo.legs)))
+                setEvent(HomeContract.HomeEvent.LoadFirstTransportationNumber(getFirstTransportationNumber(courseInfo.legs)))
+                setEvent(HomeContract.HomeEvent.LoadFirstTransportationName(getFirstTransportationName(courseInfo.legs)))
+
+                if (getFirstTransportation(courseInfo.legs) == TransportType.BUS) {
+                    if (lastRouteId.isNotEmpty()) {
+                        startPollingBusStarted(lastRouteId)
                     }
-                } catch (e: Exception) {
-                    Timber.e("CourseInfo 불러오기 실패: ${e.message}")
+                } else if (getFirstTransportation(courseInfo.legs) == TransportType.SUBWAY) {
+                    setEvent(HomeContract.HomeEvent.UpdateBusDeparted(true))
                 }
             }
 
@@ -658,7 +636,6 @@ class HomeViewModel @Inject constructor(
     }
 
     companion object {
-        private const val MY_PREFERENCES_NAME = "MyPreferences"
         private const val DEFAULT_MARKER_LAT = 37.303534788694
         private const val DEFAULT_MARKER_LON = 127.01085807594
         private const val DEFAULT_DESTINATION_LAT = 37.296391553347

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -225,6 +225,29 @@ class HomeViewModel @Inject constructor(
         return userInfoRepository.getUserID()
     }
 
+    fun checkAfterRegisterDataComplete() {
+        val currentState = currentState
+
+        val isDataComplete = when {
+            !currentState.isAlarmRegistered -> true
+            currentState.isAlarmRegistered -> {
+                currentState.departurePointName.isNotEmpty() &&
+                    currentState.departureTime.isNotEmpty() &&
+                    currentState.boardingTime.isNotEmpty() &&
+                    currentState.homeArrivedTime.isNotEmpty() &&
+                    currentState.firstTransportationName.isNotEmpty() &&
+                    currentState.itineraryInfo != null
+            }
+            else -> false
+        }
+
+        setState {
+            copy(
+                afterRegisterDataLoadState = if (isDataComplete) LoadState.Success else LoadState.Loading
+            )
+        }
+    }
+
     fun onTimerFinished() {
         setState {
             copy(
@@ -377,12 +400,30 @@ class HomeViewModel @Inject constructor(
 
     fun loadAlarmAndCourseInfoFromPrefs(context: Context) {
         viewModelScope.launch {
+            setState { copy(alarmCheckLoadState = LoadState.Loading) }
+
             val prefs = context.getSharedPreferences(MY_PREFERENCES_NAME, Context.MODE_PRIVATE)
             val isAlarmRegistered = prefs.getBoolean("alarmRegistered", false)
             val lastRouteId = prefs.getString("lastRouteId", null)
 
             setEvent(HomeContract.HomeEvent.UpdateAlarmRegistered(isAlarmRegistered))
             lastRouteId?.let { HomeContract.HomeEvent.UpdateLastRouteId(it) }?.let { setEvent(it) }
+
+            if (!isAlarmRegistered) {
+                setState {
+                    copy(
+                        alarmCheckLoadState = LoadState.Success,
+                        afterRegisterDataLoadState = LoadState.Success
+                    )
+                }
+            }
+
+            setState {
+                copy(
+                    alarmCheckLoadState = LoadState.Success,
+                    afterRegisterDataLoadState = LoadState.Loading
+                )
+            }
 
             val departurePointJson = prefs.getString("departurePoint", null)
             departurePointJson?.let {
@@ -416,6 +457,8 @@ class HomeViewModel @Inject constructor(
                     Timber.e("CourseInfo 불러오기 실패: ${e.message}")
                 }
             }
+
+            checkAfterRegisterDataComplete()
         }
     }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -1,12 +1,9 @@
 package com.depromeet.team6.presentation.ui.home
 
-import android.content.Context
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.data.datalocal.manager.LockServiceManager
 import com.depromeet.team6.domain.model.Address
 import com.depromeet.team6.domain.model.RouteLocation
-import com.depromeet.team6.domain.model.course.CourseInfo
 import com.depromeet.team6.domain.model.course.LegInfo
 import com.depromeet.team6.domain.model.course.TransportType
 import com.depromeet.team6.domain.repository.HomeRepository
@@ -29,7 +26,6 @@ import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.depromeet.team6.presentation.util.base.BaseViewModel
 import com.depromeet.team6.presentation.util.view.LoadState
 import com.google.android.gms.maps.model.LatLng
-import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -312,6 +312,7 @@ class HomeViewModel @Inject constructor(
                 }
         }
     }
+
     private fun showSpeechBubbleTemporarily() {
         speechBubbleJob?.cancel()
 
@@ -361,6 +362,16 @@ class HomeViewModel @Inject constructor(
 
         if (currentState.firtTransportTation == TransportType.BUS && currentState.isAlarmRegistered) {
             busStartedPollingJob = viewModelScope.launch {
+
+                val departureTime = LocalDateTime.parse(currentState.departureTime, DateTimeFormatter.ISO_DATE_TIME)
+                val thirtyMinutesBefore = departureTime.minusMinutes(30)
+                val now = LocalDateTime.now()
+
+                if (now.isBefore(thirtyMinutesBefore)) {
+                    val delayUntilStart = java.time.Duration.between(now, thirtyMinutesBefore).toMillis()
+                    delay(delayUntilStart)
+                }
+
                 while (isActive) {
                     Timber.d("버스 차고지 출발 여부 API 호출")
                     getBusStarted(routeId)

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -355,7 +355,6 @@ class HomeViewModel @Inject constructor(
                     if (isAllNotDefault) {
                         getTaxiCost()
                     }
-                    getTaxiCost()
                 }
                 .onFailure { exception ->
                     handleApiException(exception)
@@ -584,7 +583,6 @@ class HomeViewModel @Inject constructor(
                 if (isAllNotDefault) {
                     getTaxiCost()
                 }
-                getTaxiCost()
             }.onFailure { exception ->
                 handleApiException(exception)
             }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.depromeet.team6.presentation.ui.home
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.data.datalocal.manager.LockServiceManager
 import com.depromeet.team6.domain.model.Address
@@ -35,7 +36,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -362,21 +365,30 @@ class HomeViewModel @Inject constructor(
 
         if (currentState.firtTransportTation == TransportType.BUS && currentState.isAlarmRegistered) {
             busStartedPollingJob = viewModelScope.launch {
+                try {
+                    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+                    val departureTime = LocalTime.parse(currentState.departureTime, timeFormatter)
+                    val now = LocalDateTime.now()
 
-                val departureTime = LocalDateTime.parse(currentState.departureTime, DateTimeFormatter.ISO_DATE_TIME)
-                val thirtyMinutesBefore = departureTime.minusMinutes(30)
-                val now = LocalDateTime.now()
+                    var departureDateTimeToday = LocalDateTime.of(LocalDate.now(), departureTime)
+                    if (departureDateTimeToday.isBefore(now) || departureDateTimeToday.isEqual(now)) {
+                        departureDateTimeToday = departureDateTimeToday.plusDays(1)
+                    }
 
-                if (now.isBefore(thirtyMinutesBefore)) {
-                    val delayUntilStart = java.time.Duration.between(now, thirtyMinutesBefore).toMillis()
-                    delay(delayUntilStart)
-                }
+                    val thirtyMinutesBefore = departureDateTimeToday.minusMinutes(30)
 
-                while (isActive) {
-                    Timber.d("버스 차고지 출발 여부 API 호출")
-                    getBusStarted(routeId)
+                    if (now.isBefore(thirtyMinutesBefore)) {
+                        val delayUntilStart = java.time.Duration.between(now, thirtyMinutesBefore).toMillis()
+                        delay(delayUntilStart)
+                    }
 
-                    delay(60000)
+                    while (isActive) {
+                        Timber.d("버스 차고지 출발 여부 API 호출")
+                        getBusStarted(routeId)
+                        delay(60000)
+                    }
+                } catch (e: Exception) {
+                    Timber.e("startPollingBusStarted 오류: ${e.message}")
                 }
             }
         }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/AfterRegisterMap.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/AfterRegisterMap.kt
@@ -41,6 +41,7 @@ import com.depromeet.team6.domain.model.course.LegInfo
 import com.depromeet.team6.domain.model.course.TransportType
 import com.depromeet.team6.presentation.model.itinerary.FocusedMarkerParameter
 import com.depromeet.team6.presentation.ui.common.TransportVectorIconBitmap
+import com.depromeet.team6.presentation.ui.common.view.AtChaLoadingView
 import com.depromeet.team6.presentation.ui.itinerary.LegInfoDummyProvider
 import com.depromeet.team6.presentation.ui.itinerary.component.getWayPointList
 import com.depromeet.team6.presentation.util.permission.PermissionUtil
@@ -324,46 +325,50 @@ fun AfterRegisterMap(
     Box(
         modifier = modifier
     ) {
-        // Tmap
-        AndroidView(
-            modifier = modifier
-                .fillMaxWidth()
-                // TODO : 하단 모달 영역 제외한 부분에 띄우도록 수정
-                .height(screenHeight - 248.dp + padding.calculateBottomPadding())
-                .align(Alignment.TopCenter),
-            factory = { context ->
-                // FrameLayout을 직접 생성
-                FrameLayout(context).apply {
-                    // TMapView를 FrameLayout에 추가
-                    addView(tMapView)
-                }
-            },
-            update = { frameLayout ->
-                // Update logic if needed (e.g., map settings)
-            }
-        )
-
-        // 현위치 버튼
-        Image(
-            imageVector = ImageVector.vectorResource(id = R.drawable.ic_all_current_location),
-            contentDescription = stringResource(R.string.home_current_location_btn),
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .then(
-                    if (isAlarmRegistered) {
-                        Modifier.padding(bottom = 25.dp, end = 16.dp)
-                    } else {
-                        Modifier.padding(bottom = 25.dp, end = 16.dp)
+        if (isMapReady) {
+            // Tmap
+            AndroidView(
+                modifier = modifier
+                    .fillMaxWidth()
+                    // TODO : 하단 모달 영역 제외한 부분에 띄우도록 수정
+                    .height(screenHeight - 248.dp + padding.calculateBottomPadding())
+                    .align(Alignment.TopCenter),
+                factory = { context ->
+                    // FrameLayout을 직접 생성
+                    FrameLayout(context).apply {
+                        // TMapView를 FrameLayout에 추가
+                        addView(tMapView)
                     }
-                )
-                .clickable(enabled = isMapReady) {
-                    val tMapPoint = TMapPoint(userLocation.latitude, userLocation.longitude)
-                    tMapView.setCenterPoint(tMapPoint.latitude, tMapPoint.longitude)
-
-                    getCenterLocation(LatLng(tMapPoint.latitude, tMapPoint.longitude))
+                },
+                update = { frameLayout ->
+                    // Update logic if needed (e.g., map settings)
                 }
-                .graphicsLayer { alpha = if (isMapReady) 1f else 0.5f } // 비활성화 시 투명도 조정
-        )
+            )
+
+            // 현위치 버튼
+            Image(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_all_current_location),
+                contentDescription = stringResource(R.string.home_current_location_btn),
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .then(
+                        if (isAlarmRegistered) {
+                            Modifier.padding(bottom = 25.dp, end = 16.dp)
+                        } else {
+                            Modifier.padding(bottom = 25.dp, end = 16.dp)
+                        }
+                    )
+                    .clickable(enabled = isMapReady) {
+                        val tMapPoint = TMapPoint(userLocation.latitude, userLocation.longitude)
+                        tMapView.setCenterPoint(tMapPoint.latitude, tMapPoint.longitude)
+
+                        getCenterLocation(LatLng(tMapPoint.latitude, tMapPoint.longitude))
+                    }
+                    .graphicsLayer { alpha = if (isMapReady) 1f else 0.5f } // 비활성화 시 투명도 조정
+            )
+        } else {
+            AtChaLoadingView()
+        }
     }
 }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
@@ -7,9 +7,11 @@ import android.widget.Toast
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.R
 import com.depromeet.team6.data.dataremote.model.request.user.RequestModifyUserInfoDto
+import com.depromeet.team6.data.repositoryimpl.HomeRepositoryImpl
 import com.depromeet.team6.data.repositoryimpl.UserInfoRepositoryImpl
 import com.depromeet.team6.domain.model.Address
 import com.depromeet.team6.domain.model.MypageUserInfo
+import com.depromeet.team6.domain.repository.HomeRepository
 import com.depromeet.team6.domain.usecase.DeleteWithDrawUseCase
 import com.depromeet.team6.domain.usecase.GetAddressFromCoordinatesUseCase
 import com.depromeet.team6.domain.usecase.GetLocationsUseCase
@@ -33,6 +35,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MypageViewModel @Inject constructor(
     private val userInfoRepositoryImpl: UserInfoRepositoryImpl,
+    private val homeRepository: HomeRepository,
     private val postLogoutUseCase: PostLogoutUseCase,
     private val getLocationsUseCase: GetLocationsUseCase,
     private val getAddressFromCoordinatesUseCase: GetAddressFromCoordinatesUseCase,
@@ -402,6 +405,7 @@ class MypageViewModel @Inject constructor(
                 setSideEffect(MypageContract.MypageSideEffect.NavigateToLogin)
                 setState { copy(loadState = LoadState.Error) }
                 userInfoRepositoryImpl.clear()
+                homeRepository.clearAlarmData()
             }.onFailure { exception ->
                 setEvent(MypageContract.MypageEvent.LogoutClicked)
                 handleApiException(exception = exception)
@@ -413,6 +417,7 @@ class MypageViewModel @Inject constructor(
         viewModelScope.launch {
             deleteWithDrawUseCase().onSuccess {
                 userInfoRepositoryImpl.clear()
+                homeRepository.clearAlarmData()
                 setSideEffect(MypageContract.MypageSideEffect.NavigateToLogin)
             }.onFailure { exception ->
                 handleApiException(exception = exception)

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
@@ -7,7 +7,6 @@ import android.widget.Toast
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.R
 import com.depromeet.team6.data.dataremote.model.request.user.RequestModifyUserInfoDto
-import com.depromeet.team6.data.repositoryimpl.HomeRepositoryImpl
 import com.depromeet.team6.data.repositoryimpl.UserInfoRepositoryImpl
 import com.depromeet.team6.domain.model.Address
 import com.depromeet.team6.domain.model.MypageUserInfo


### PR DESCRIPTION
## #️⃣연관된 이슈

- #172 

## 📝작업 내용

- 알림 등록 후 홈화면 로딩 처리
- HomeInfoLocalDataSource 생성하여 알림 등록 후 홈 화면 관련 정보 관리하도록 변경
- 로그아웃, 회원탈퇴 시 알림 관련 정보 삭제해서 이전 모달 창 안 뜨도록 해결
- 버스 출발 여부 호출하여 예상 출발 시간 표시하는 로직을 알림 시간 30분 전부터만 실행하도록 변경

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 💬리뷰 요구사항
**브랜치를 [fix/mypage-home-taxi#170](https://github.com/depromeet/16th-team6-Android/tree/fix/mypage-home-taxi%23170) 기준으로 파서, 머지하기 전에 develop으로 바꿔서 머지 필요함 !!**
- 노션 QA 리스트 중 **앱 로딩 시간/ 메인 화면 와라락, 튕김 이슈** 에서
[ 다른 앱 활동을 하다가 접근하면 앱을 눌렀을 때 화면이 바로 켜지지 않음 → 약 3~5초정도 대기해야 앱이 켜짐. ] 이 부분은 어떤 문제인지 모르겠어서 제외하고 해결했습니다. 테스트 한번 해봐주세요 ~ !