### PR TITLE
[#179] 메인 화면 지도 버그

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
@@ -54,13 +54,15 @@ fun TMapViewCompose(
     getCenterLocation: (LatLng) -> Unit
 ) {
     val context = LocalContext.current
-    val tMapView = remember { TMapView(context) }
+    val tMapViewState = remember { mutableStateOf<TMapView?>(null) }
     var isMapReady by remember { mutableStateOf(false) }
 
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
 
     // 현재 위치 변경될 때만 현위치 마커 갱신
     LaunchedEffect(currentLocation, isMapReady) {
+        val tMapView = tMapViewState.value ?: return@LaunchedEffect
+
         if (isMapReady) {
             val tMapPoint = TMapPoint(currentLocation.latitude, currentLocation.longitude)
 
@@ -99,29 +101,30 @@ fun TMapViewCompose(
                 .height(screenHeight - 200.dp + padding.calculateTopPadding())
                 .align(Alignment.TopCenter),
             factory = { context ->
+                val tMapView = TMapView(context).apply {
+                    setSKTMapApiKey(BuildConfig.TMAP_API_KEY)
 
-                tMapView.setSKTMapApiKey(BuildConfig.TMAP_API_KEY)
-                tMapView.setOnMapReadyListener {
-                    tMapView.mapType = TMapView.MapType.NIGHT
-                    isMapReady = true
+                    setOnMapReadyListener {
+                        mapType = TMapView.MapType.NIGHT
+                        isMapReady = true
 
-                    // 드래그 종료 시 지도 중심 좌표 업데이트
-                    tMapView.setOnDisableScrollWithZoomLevelListener { _, _ ->
-                        val centerLat = tMapView.centerPoint.latitude
-                        val centerLon = tMapView.centerPoint.longitude
+                        setOnDisableScrollWithZoomLevelListener { _, _ ->
+                            val center = centerPoint
+                            getCenterLocation(LatLng(center.latitude, center.longitude))
 
-                        getCenterLocation(LatLng(centerLat, centerLon))
-
-                        AmplitudeUtils.trackEventWithProperties(
-                            eventName = HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG,
-                            mapOf(
-                                USER_ID to userId,
-                                SCREEN_NAME to HOME,
-                                HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG to true
+                            AmplitudeUtils.trackEventWithProperties(
+                                eventName = HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG,
+                                mapOf(
+                                    USER_ID to userId,
+                                    SCREEN_NAME to HOME,
+                                    HOME_COURSESEARCH_ENTERED_WITH_MAP_DRAG to true
+                                )
                             )
-                        )
+                        }
                     }
                 }
+
+                tMapViewState.value = tMapView
 
                 // FrameLayout을 직접 생성
                 FrameLayout(context).apply {
@@ -160,7 +163,10 @@ fun TMapViewCompose(
                     .clickable(enabled = isMapReady) {
                         val tMapPoint =
                             TMapPoint(currentLocation.latitude, currentLocation.longitude)
-                        tMapView.setCenterPoint(tMapPoint.latitude, tMapPoint.longitude)
+
+                        tMapViewState.value?.apply {
+                            setCenterPoint(tMapPoint.latitude, tMapPoint.longitude)
+                        }
                         getCenterLocation(LatLng(tMapPoint.latitude, tMapPoint.longitude))
 
                         AmplitudeUtils.trackEventWithProperties(
@@ -182,7 +188,7 @@ fun TMapViewCompose(
     DisposableEffect(Unit) {
         onDispose {
             Timber.d("TMapViewCompose destroy!")
-            tMapView.onDestroy()
+            tMapViewState.value?.onDestroy()
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #179

## 📝작업 내용

### 문제
- QA 시에 경로 확인 후에 메인 화면으로 돌아오면 종종 지도가 회색으로 뜨는 버그가 발생했습니다

### 해결
- 기존에는 Composable 내에서 remember { TMapView(context) } 로 TMapView 인스턴스를 생성하여 재사용했습니다.
- 그런데 Navigation을 통해 화면 복귀 시 Composable은 재생성되지만 (화면 전환 시 Context가 재생성 될 수 있음), remember 된 이전의 Context가 유지되면서 Context 불일치로 인해 렌더링 실패(지도 회색 화면)가 발생할 수 있다고 하더라구요.
그래서 일단 AndroidView의 factory 내부에서 매번 TMapView를 새로 생성하도록 변경하여 항상 최신 Context를 사용하도록 수정해보았습니다.

만약 이게 문제가 맞았다면 지도 회색 화면은 해결이 될 것 같은데, 다만 화면을 이동할 때마다 지도를 다시 그리게 됩니다 ㅠㅠ,,,
일단 테스트 해보고 Navigation 때문에 발생한 버그가 맞다면 이 부분은 다시 고민해 보도록 하겠습니다.

## PR 발행 전 체크 리스트

- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인
- [ ] 코드 린트 확인

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
