### PR TITLE
[#191] : 마이페이지, 온보딩 트래킹코드 추가

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageScreen.kt
@@ -40,8 +40,13 @@ import com.depromeet.team6.presentation.ui.mypage.component.MypageListItem
 import com.depromeet.team6.presentation.ui.mypage.component.MypageVersionItem
 import com.depromeet.team6.presentation.ui.mypage.component.TitleBar
 import com.depromeet.team6.presentation.ui.onboarding.component.OnboardingSearchPopup
+import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
+import com.depromeet.team6.presentation.util.MyPageAmplitude.MYPAGE_BANNER_CLICKED
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER_COMPLETE_CLICKED
 import com.depromeet.team6.presentation.util.WebViewUrl.FEEDBACK_FORM_URL
 import com.depromeet.team6.presentation.util.WebViewUrl.PRIVACY_POLICY_URL
+import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.depromeet.team6.presentation.util.base.ApiErrorSideEffect
 import com.depromeet.team6.presentation.util.dialog.LocalDialogController
 import com.depromeet.team6.presentation.util.modifier.noRippleClickable
@@ -79,6 +84,9 @@ fun MypageRoute(
                     is MypageContract.MypageSideEffect.NavigateToLogin -> navigateToLogin()
                     is MypageContract.MypageSideEffect.NavigateToFeedbackForm -> {
                         context.startActivity(feedbackIntent)
+                        AmplitudeUtils.trackEvent(
+                            eventName = MYPAGE_BANNER_CLICKED
+                        )
                     }
                     is ApiErrorSideEffect.ShowToastSideEffect -> {
                         Toast.makeText(context, sideEffect.toastMessage, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageScreen.kt
@@ -40,10 +40,7 @@ import com.depromeet.team6.presentation.ui.mypage.component.MypageListItem
 import com.depromeet.team6.presentation.ui.mypage.component.MypageVersionItem
 import com.depromeet.team6.presentation.ui.mypage.component.TitleBar
 import com.depromeet.team6.presentation.ui.onboarding.component.OnboardingSearchPopup
-import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
 import com.depromeet.team6.presentation.util.MyPageAmplitude.MYPAGE_BANNER_CLICKED
-import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER
-import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER_COMPLETE_CLICKED
 import com.depromeet.team6.presentation.util.WebViewUrl.FEEDBACK_FORM_URL
 import com.depromeet.team6.presentation.util.WebViewUrl.PRIVACY_POLICY_URL
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingScreen.kt
@@ -49,9 +49,13 @@ import com.depromeet.team6.presentation.ui.onboarding.component.OnboardingTitle
 import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.ALARM_REGISTER
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.ALARM_SETTING_ALARM_PERMISSION_CLICKED
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.CLOSE
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER_COMPLETE_CLICKED
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER_LOCATION_PERMISSION_CHECK
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.SYSTEM_SETTING
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.depromeet.team6.presentation.util.dialog.LocalDialogController
 import com.depromeet.team6.presentation.util.modifier.noRippleClickable
@@ -128,6 +132,20 @@ fun OnboardingRoute(
                     is OnboardingContract.OnboardingSideEffect.LocationPermissionDeniedDialog -> {
                         dialogController.showSystemSettingsDialog(
                             context = context,
+                            onConfirm = {
+                                AmplitudeUtils.trackEventWithProperty(
+                                    eventName = ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyName = ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyValue = SYSTEM_SETTING
+                                )
+                            },
+                            onDismiss = {
+                                AmplitudeUtils.trackEventWithProperty(
+                                    eventName = ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyName = ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyValue = CLOSE
+                                )
+                            },
                             message = context.getString(R.string.onboarding_location_permission_denied_dialog)
                         )
                     }
@@ -135,6 +153,20 @@ fun OnboardingRoute(
                     is OnboardingContract.OnboardingSideEffect.NotificationPermissionDeniedDialog -> {
                         dialogController.showSystemSettingsDialog(
                             context = context,
+                            onConfirm = {
+                                AmplitudeUtils.trackEventWithProperty(
+                                    eventName = ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyName = ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyValue = SYSTEM_SETTING
+                                )
+                            },
+                            onDismiss = {
+                                AmplitudeUtils.trackEventWithProperty(
+                                    eventName = ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyName = ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED,
+                                    propertyValue = CLOSE
+                                )
+                            },
                             message = context.getString(R.string.onboarding_notification_permission_denied_dialog)
                         )
                     }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingScreen.kt
@@ -49,11 +49,14 @@ import com.depromeet.team6.presentation.ui.onboarding.component.OnboardingTitle
 import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.ALARM_REGISTER
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.ALARM_SETTING_ALARM_PERMISSION_CLICKED
-import com.depromeet.team6.presentation.util.OnboardingAmplitude.CLOSE
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.DENIED
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.GRANT
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER_COMPLETE_CLICKED
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.HOME_REGISTER_LOCATION_PERMISSION_CHECK
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.ONBOARDING_LOCATION_PERMISSION_CLICKED
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.ONBOARDING_NOTIFICATION_PERMISSION_CLICKED
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED
 import com.depromeet.team6.presentation.util.OnboardingAmplitude.SYSTEM_SETTING
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
@@ -82,8 +85,18 @@ fun OnboardingRoute(
             val anyDenied = permissions.any { !it.value }
 
             if (anyDenied) {
+                AmplitudeUtils.trackEventWithProperty(
+                    eventName = ONBOARDING_LOCATION_PERMISSION_CLICKED,
+                    propertyName = ONBOARDING_LOCATION_PERMISSION_CLICKED,
+                    propertyValue = DENIED
+                )
                 viewModel.setSideEffect(OnboardingContract.OnboardingSideEffect.LocationPermissionDeniedDialog)
             } else {
+                AmplitudeUtils.trackEventWithProperty(
+                    eventName = ONBOARDING_LOCATION_PERMISSION_CLICKED,
+                    propertyName = ONBOARDING_LOCATION_PERMISSION_CLICKED,
+                    propertyValue = GRANT
+                )
                 Timber.d("Location_Permission Has Granted")
             }
         }
@@ -93,8 +106,18 @@ fun OnboardingRoute(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = { granted ->
             if (granted) {
+                AmplitudeUtils.trackEventWithProperty(
+                    eventName = ONBOARDING_NOTIFICATION_PERMISSION_CLICKED,
+                    propertyName = ONBOARDING_NOTIFICATION_PERMISSION_CLICKED,
+                    propertyValue = GRANT
+                )
                 Timber.d("Notification_Permission Has Granted")
             } else {
+                AmplitudeUtils.trackEventWithProperty(
+                    eventName = ONBOARDING_NOTIFICATION_PERMISSION_CLICKED,
+                    propertyName = ONBOARDING_NOTIFICATION_PERMISSION_CLICKED,
+                    propertyValue = DENIED
+                )
                 viewModel.setSideEffect(OnboardingContract.OnboardingSideEffect.NotificationPermissionDeniedDialog)
             }
         }
@@ -143,7 +166,7 @@ fun OnboardingRoute(
                                 AmplitudeUtils.trackEventWithProperty(
                                     eventName = ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED,
                                     propertyName = ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED,
-                                    propertyValue = CLOSE
+                                    propertyValue = DENIED
                                 )
                             },
                             message = context.getString(R.string.onboarding_location_permission_denied_dialog)
@@ -164,7 +187,7 @@ fun OnboardingRoute(
                                 AmplitudeUtils.trackEventWithProperty(
                                     eventName = ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED,
                                     propertyName = ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED,
-                                    propertyValue = CLOSE
+                                    propertyValue = DENIED
                                 )
                             },
                             message = context.getString(R.string.onboarding_notification_permission_denied_dialog)

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -10,10 +10,7 @@ import com.depromeet.team6.domain.usecase.GetLocationsUseCase
 import com.depromeet.team6.domain.usecase.PostSignUpUseCase
 import com.depromeet.team6.presentation.mapper.toPresentationList
 import com.depromeet.team6.presentation.type.OnboardingType
-import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
-import com.depromeet.team6.presentation.util.AmplitudeCommon.USER_ID
-import com.depromeet.team6.presentation.util.OnboardingAmplitude.ALARM_REGISTER
-import com.depromeet.team6.presentation.util.OnboardingAmplitude.USER_ALARM_FREQUENCIES
+import com.depromeet.team6.presentation.util.OnboardingAmplitude.USER_PUSH_FREQUENCIES
 import com.depromeet.team6.presentation.util.Provider.KAKAO
 import com.depromeet.team6.presentation.util.Token.BEARER
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
@@ -151,13 +148,10 @@ class OnboardingViewModel @Inject constructor(
                 userInfoRepository.setUserHome(auth.userHome)
                 userInfoRepository.setUserId(auth.id)
                 AmplitudeUtils.setUserId(userId = auth.id)
-                AmplitudeUtils.trackEventWithProperties(
-                    eventName = USER_ALARM_FREQUENCIES,
-                    mapOf(
-                        USER_ID to auth.id,
-                        SCREEN_NAME to ALARM_REGISTER,
-                        USER_ALARM_FREQUENCIES to uiState.value.alertFrequencies
-                    )
+                AmplitudeUtils.trackEventWithProperty(
+                    eventName = USER_PUSH_FREQUENCIES,
+                    propertyName = USER_PUSH_FREQUENCIES,
+                    propertyValue = uiState.value.alertFrequencies,
                 )
             }.onFailure { exception ->
                 setEvent(OnboardingContract.OnboardingEvent.PostSignUp(loadState = LoadState.Error))

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -151,7 +151,7 @@ class OnboardingViewModel @Inject constructor(
                 AmplitudeUtils.trackEventWithProperty(
                     eventName = USER_PUSH_FREQUENCIES,
                     propertyName = USER_PUSH_FREQUENCIES,
-                    propertyValue = uiState.value.alertFrequencies,
+                    propertyValue = uiState.value.alertFrequencies
                 )
             }.onFailure { exception ->
                 setEvent(OnboardingContract.OnboardingEvent.PostSignUp(loadState = LoadState.Error))

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -53,6 +53,10 @@ object OnboardingAmplitude {
     const val ALARM_SETTING_ALARM_PERMISSION_CLICKED = "alarm_setting_alarm_permission_clicked"
     const val HOME_REGISTER = "집 등록(온보딩)"
     const val ALARM_REGISTER = "알림 등록(온보딩)"
+    const val ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED = "onboarding_notification_permission_settings_clicked"
+    const val ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED = "onboarding_location_permission_settings_clicked"
+    const val SYSTEM_SETTING = "설정하기"
+    const val CLOSE = "허용안함"
 }
 
 object HomeAmplitude {

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -47,7 +47,7 @@ object AmplitudeCommon {
 }
 
 object OnboardingAmplitude {
-    const val USER_ALARM_FREQUENCIES = "user_alarm_frequencies"
+    const val USER_PUSH_FREQUENCIES = "user_push_frequencies"
     const val HOME_REGISTER_LOCATION_PERMISSION_CHECK = "home_register_location_permission_clicked"
     const val HOME_REGISTER_COMPLETE_CLICKED = "home_register_complete_clicked"
     const val ALARM_SETTING_ALARM_PERMISSION_CLICKED = "alarm_setting_alarm_permission_clicked"

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -56,7 +56,11 @@ object OnboardingAmplitude {
     const val ONBOARDING_NOTIFICATION_PERMISSION_SETTINGS_CLICKED = "onboarding_notification_permission_settings_clicked"
     const val ONBOARDING_LOCATION_PERMISSION_SETTINGS_CLICKED = "onboarding_location_permission_settings_clicked"
     const val SYSTEM_SETTING = "설정하기"
-    const val CLOSE = "허용안함"
+    const val DENIED = "허용안함"
+    const val GRANT = "허용"
+    const val ONBOARDING_LOCATION_PERMISSION_CLICKED = "onboarding_location_permission_clicked"
+    const val ONBOARDING_NOTIFICATION_PERMISSION_CLICKED = "onboarding_notification_permission_clicked"
+    const val ONBOARDING_COMPLETE = "onboarding_complete"
 }
 
 object HomeAmplitude {

--- a/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/util/Constraints.kt
@@ -102,3 +102,8 @@ object ItineraryAmplitude {
     const val ITINERARY_EVENT_ALARM_REGISTERED = "alert_button"
     const val ITINERARY_ALARM_REGISTER_BTN_CLICKED = "alert_button"
 }
+
+object MyPageAmplitude {
+    const val MY_PAGE = "마이페이지"
+    const val MYPAGE_BANNER_CLICKED = "mypage_banner_clicked"
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #191 

## 📝작업 내용
온보딩 트래킹 코드 변경사항을 적용하고 마이페이지 트래킹 코드를 추가합니다
- 알림 권한 설정하기 클릭
- 위치 권한 설정하기 클릭
- 알림 권한 허용 여부 클릭 수
- 알림 권한 허용 여부
- 사용자가 등록한 알람 빈도
- 마이페이지 피드백 배너 클릭
- 온보딩 완료 (논의 후 추가)

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 플로우 상 알람 빈도 트래킹 코드가 존재해서 노션에 기재된 온보딩 완료 트래킹코드는 중복이라고 생각하는데, 다른분들 의견도 궁금합니다!
  - 그리고 위치 권한에서 [허용], [허용 안함]은 분기처리가 가능하지만 [한 번 허용]은 어떻게 구분하는지 아시는분 계실까요?
  (저는 백그라운드 권한 여부로 항상 허용인지 한 번 허용인지 구분하려고 하는데 이 방법이 맞는지 모르겠네요)