### PR TITLE
[#193] : 사용자 위치 정류장 판단로직 수정

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/bus/BusCourseScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/bus/BusCourseScreen.kt
@@ -122,10 +122,10 @@ fun BusCourseScreen(
 
     val listState = rememberLazyListState()
     val currentIndex = uiState.busRouteStationList.indexOfFirst {
-        it.busStationNumber == uiState.currentBusStationId
+        it.busStationId == uiState.currentBusStationId
     }
 
-    val targetIndex = maxOf(currentIndex - 3, 0)
+    val targetIndex = maxOf(currentIndex - 4, 0)
 
     LaunchedEffect(currentIndex) {
         if (currentIndex != -1) {
@@ -217,7 +217,7 @@ fun BusCourseScreen(
                         busSubtypeIdx = uiState.busArrivalParameter.subtypeIdx,
                         isTurnPoint = (busRouteStation.order == uiState.turnPoint),
                         afterTurnPoint = (busRouteStation.order > uiState.turnPoint),
-                        isCurrentStation = (busRouteStation.busStationNumber == uiState.currentBusStationId),
+                        isCurrentStation = (busRouteStation.busStationId == uiState.currentBusStationId),
                         busRemainTime = uiState.remainingTime,
                         busStatus = uiState.busStatus,
                         busPosition = uiState.busPositions.find {


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #193

## 📝작업 내용
사용자 위치 정류장을 화면 가운데 위치시키고 남은시간을 표시해야 하는데 제대로 동작하지 않던 형상을 해결했습니다.
- busStationNumber -> busStationId

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 원래 busStationNumber로 판단해야 돌아가던 코드가 왜 갑자기 busStationId로 바꿔야 돌아가는지 모르겠네요