### PR TITLE
[#197] 홈 화면 버튼 위치 수정

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -639,7 +639,7 @@ fun HomeScreen(
             contentDescription = stringResource(R.string.mypage_icon_description),
             modifier = Modifier
                 .align(Alignment.TopEnd)
-                .padding(top = 12.dp + padding.calculateTopPadding(), end = 16.dp)
+                .padding(top = 12.dp, end = 16.dp)
                 .clickable {
                     navigateToMypage()
                 }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
@@ -152,9 +152,9 @@ fun TMapViewCompose(
                     .align(Alignment.BottomEnd)
                     .then(
                         if (isAlarmRegistered) {
-                            Modifier.padding(bottom = 55.dp, end = 16.dp)
+                            Modifier.padding(bottom = 75.dp, end = 16.dp)
                         } else {
-                            Modifier.padding(bottom = 55.dp, end = 16.dp)
+                            Modifier.padding(bottom = 75.dp, end = 16.dp)
                         }
                     )
                     .clickable(enabled = isMapReady) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #197 

## 📝작업 내용
- 홈 화면 현위치 버튼 위치 수정
- 홈 화면 마이페이지 버튼 위치 수정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)
- 기기 작은 버전
<img width="360" height="800" alt="앗차1" src="https://github.com/user-attachments/assets/5baa468a-4f85-4cf7-8a76-b66c699e1bd7" />

- 기기 큰 버전
<img width="360" height="800" alt="앗차1" src="https://github.com/user-attachments/assets/8522c62f-f61a-4136-a031-f9c00bddc28d" />


## 💬리뷰 요구사항(선택)
- 지원언니가 디코 QA에 올려둔 버튼 밀림 현상 PR입니다.
- 마이페이지 버튼은 제가 이전 pr에서 status bar 패딩 적용하면서 마이페이지 버튼 top 패딩 적용한 거랑 겹치면서 아래로 밀린 것 같아서, 마이페이지에서 12.dp만 남겨두고 `padding.calculateTopPadding()` 은 제거 했습니다!!