### PR TITLE
[#213] 버스 운행시간 상행&하행 분기처리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     implementation(libs.play.services.location)
     implementation(libs.play.services.auth)
     implementation(libs.androidx.runtime.livedata)
+    implementation(libs.accompanist.flowlayout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/depromeet/team6/data/mapper/todomain/ResponseBusOperationInfoDtoMapper.kt
+++ b/app/src/main/java/com/depromeet/team6/data/mapper/todomain/ResponseBusOperationInfoDtoMapper.kt
@@ -2,6 +2,7 @@ package com.depromeet.team6.data.mapper.todomain
 
 import com.depromeet.team6.data.dataremote.model.response.transits.BusServiceHour
 import com.depromeet.team6.data.dataremote.model.response.transits.ResponseBusOperationInfoDto
+import com.depromeet.team6.domain.model.BusDirection
 import com.depromeet.team6.domain.model.BusOperationInfo
 import com.depromeet.team6.presentation.util.BusOperationInfo.HOLIDAY
 import com.depromeet.team6.presentation.util.BusOperationInfo.HOLIDAY_KR
@@ -24,7 +25,7 @@ fun ResponseBusOperationInfoDto.toDomain(): BusOperationInfo {
 fun BusServiceHour.toDomain(): com.depromeet.team6.domain.model.BusServiceHour {
     return com.depromeet.team6.domain.model.BusServiceHour(
         dailyType = dailyTypeMapper(this.dailyType),
-        busDirection = this.busDirection.toString(),
+        busDirection = BusDirection.valueOf(this.busDirection.toString()),
         startTime = if (this.startTime != null) timeMapper(this.startTime) else null,
         endTime = if (this.endTime != null) timeMapper(this.endTime) else null,
         term = this.term

--- a/app/src/main/java/com/depromeet/team6/domain/model/BusOperationInfo.kt
+++ b/app/src/main/java/com/depromeet/team6/domain/model/BusOperationInfo.kt
@@ -14,7 +14,7 @@ data class BusServiceHour(
     val term: Int
 )
 
-enum class BusDirection(val text: String){
+enum class BusDirection(val text: String) {
     UP("상행"),
     DOWN("하행")
 }

--- a/app/src/main/java/com/depromeet/team6/domain/model/BusOperationInfo.kt
+++ b/app/src/main/java/com/depromeet/team6/domain/model/BusOperationInfo.kt
@@ -8,8 +8,13 @@ data class BusOperationInfo(
 
 data class BusServiceHour(
     val dailyType: String,
-    val busDirection: String,
+    val busDirection: BusDirection,
     val startTime: String?,
     val endTime: String?,
     val term: Int
 )
+
+enum class BusDirection(val text: String){
+    UP("상행"),
+    DOWN("하행")
+}

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/bus/component/BusOperationInfo.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/bus/component/BusOperationInfo.kt
@@ -49,6 +49,14 @@ fun BusOperationInfoView(
     val upList = busOperationInfo.serviceHours.filter { it.busDirection == BusDirection.UP }
     val downList = busOperationInfo.serviceHours.filter { it.busDirection == BusDirection.DOWN }
 
+    val dailyTypeMap = remember(busOperationInfo) {
+        busOperationInfo.serviceHours
+            .filter { it.startTime != null && it.endTime != null }
+            .groupBy { it.dailyType }
+    }
+
+    val typeOrder = listOf("평일", "토요일", "공휴일")
+
     val isOneWay by remember(upList, downList) {
         derivedStateOf {
             (upList.isEmpty() || downList.isEmpty())
@@ -126,24 +134,35 @@ fun BusOperationInfoView(
                 modifier = horizontalModifier
             )
         }
-        (upList + downList).forEach { serviceHour ->
-            if (serviceHour.startTime == null || serviceHour.endTime == null) return@forEach
+        typeOrder.forEach { dailyType ->
+            val list = dailyTypeMap[dailyType].orEmpty()
+
+            val up = list.firstOrNull { it.busDirection == BusDirection.UP }
+            val down = list.firstOrNull { it.busDirection == BusDirection.DOWN }
+
+            if (up == null && down == null) return@forEach
+
             Spacer(modifier = Modifier.height(6.dp))
             Row(modifier = horizontalModifier, verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = serviceHour.dailyType,
+                    text = if (dailyType == "평일") "$dailyType  " else dailyType,
                     style = defaultTeam6Typography.bodyRegular13,
                     color = defaultTeam6Colors.gray200
                 )
                 Spacer(modifier = Modifier.width(16.dp))
-                Text(
-                    text = buildString {
-                        append("${serviceHour.startTime} ~ ${serviceHour.endTime}")
-                        if (!isOneWay) append(" (${serviceHour.busDirection.text})")
-                    },
-                    style = defaultTeam6Typography.bodyRegular14,
-                    color = defaultTeam6Colors.white
-                )
+                if (isOneWay) {
+                    Text(
+                        text = "${up?.startTime ?: "-"} ~ ${up?.endTime ?: "-"}",
+                        style = defaultTeam6Typography.bodyRegular14,
+                        color = defaultTeam6Colors.white
+                    )
+                } else {
+                    Text(
+                        text = "${BusDirection.UP.text} ${up?.startTime ?: "-"} ~ ${up?.endTime ?: "-"} / ${BusDirection.DOWN.text} ${down?.startTime ?: "-"} ~ ${down?.endTime ?: "-"}",
+                        style = defaultTeam6Typography.bodyRegular14,
+                        color = defaultTeam6Colors.white
+                    )
+                }
             }
         }
         Spacer(modifier = Modifier.height(32.dp))
@@ -155,69 +174,40 @@ fun BusOperationInfoView(
         )
         Spacer(modifier = Modifier.height(6.dp))
 
-        Row(
-            modifier = horizontalModifier
-        ) {
-            if (!isOneWay) {
-                Text(
-                    text = "상행",
-                    style = defaultTeam6Typography.bodyRegular14,
-                    color = defaultTeam6Colors.white
-                )
-                Spacer(modifier = Modifier.width(10.dp))
-            }
+        listOf(
+            BusDirection.UP to upList,
+            BusDirection.DOWN to downList
+        ).forEach { (busDirection, list) ->
+            if (list.isEmpty()) return@forEach
 
-            FlowRow(
-                mainAxisSpacing = 15.dp,
-                crossAxisSpacing = 8.dp
-            ) {
-                upList.forEach { serviceHour ->
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = serviceHour.dailyType,
-                            style = defaultTeam6Typography.bodyRegular13,
-                            color = defaultTeam6Colors.gray200
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "${serviceHour.term}분",
-                            style = defaultTeam6Typography.bodyRegular14,
-                            color = defaultTeam6Colors.white
-                        )
-                    }
+            Row(modifier = horizontalModifier) {
+                if (!isOneWay) {
+                    Text(
+                        text = busDirection.text,
+                        style = defaultTeam6Typography.bodyRegular14,
+                        color = defaultTeam6Colors.white
+                    )
+                    Spacer(Modifier.width(10.dp))
                 }
-            }
-        }
 
-        Row(
-            modifier = horizontalModifier
-        ) {
-            if (!isOneWay) {
-                Text(
-                    text = "하행",
-                    style = defaultTeam6Typography.bodyRegular14,
-                    color = defaultTeam6Colors.white
-                )
-                Spacer(modifier = Modifier.width(10.dp))
-            }
-
-            FlowRow(
-                mainAxisSpacing = 15.dp,
-                crossAxisSpacing = 8.dp
-            ) {
-                downList.forEach { serviceHour ->
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = serviceHour.dailyType,
-                            style = defaultTeam6Typography.bodyRegular13,
-                            color = defaultTeam6Colors.gray200
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "${serviceHour.term}분",
-                            style = defaultTeam6Typography.bodyRegular14,
-                            color = defaultTeam6Colors.white
-                        )
+                FlowRow(
+                    mainAxisSpacing = 15.dp,
+                    crossAxisSpacing = 8.dp
+                ) {
+                    list.forEach { serviceHour ->
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = serviceHour.dailyType,
+                                style = defaultTeam6Typography.bodyRegular13,
+                                color = defaultTeam6Colors.gray200
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                text = "${serviceHour.term}분",
+                                style = defaultTeam6Typography.bodyRegular14,
+                                color = defaultTeam6Colors.white
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/bus/component/BusOperationInfo.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/bus/component/BusOperationInfo.kt
@@ -15,6 +15,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,6 +26,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.depromeet.team6.R
+import com.depromeet.team6.domain.model.BusDirection
 import com.depromeet.team6.domain.model.BusOperationInfo
 import com.depromeet.team6.domain.model.course.TransportType
 import com.depromeet.team6.presentation.ui.common.TransportVectorIconComposable
@@ -30,6 +34,7 @@ import com.depromeet.team6.presentation.util.modifier.noRippleClickable
 import com.depromeet.team6.ui.theme.LocalTeam6Colors
 import com.depromeet.team6.ui.theme.defaultTeam6Colors
 import com.depromeet.team6.ui.theme.defaultTeam6Typography
+import com.google.accompanist.flowlayout.FlowRow
 
 @Composable
 fun BusOperationInfoView(
@@ -40,6 +45,16 @@ fun BusOperationInfoView(
     backButtonClicked: () -> Unit = {}
 ) {
     val horizontalModifier = Modifier.padding(horizontal = 16.dp)
+
+    val upList = busOperationInfo.serviceHours.filter { it.busDirection == BusDirection.UP }
+    val downList = busOperationInfo.serviceHours.filter { it.busDirection == BusDirection.DOWN }
+
+    val isOneWay by remember(upList, downList) {
+        derivedStateOf {
+            (upList.isEmpty() || downList.isEmpty())
+        }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -111,7 +126,7 @@ fun BusOperationInfoView(
                 modifier = horizontalModifier
             )
         }
-        busOperationInfo.serviceHours.forEach { serviceHour ->
+        (upList + downList).forEach { serviceHour ->
             if (serviceHour.startTime == null || serviceHour.endTime == null) return@forEach
             Spacer(modifier = Modifier.height(6.dp))
             Row(modifier = horizontalModifier, verticalAlignment = Alignment.CenterVertically) {
@@ -122,7 +137,10 @@ fun BusOperationInfoView(
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 Text(
-                    text = "${serviceHour.startTime} ~ ${serviceHour.endTime}",
+                    text = buildString {
+                        append("${serviceHour.startTime} ~ ${serviceHour.endTime}")
+                        if (!isOneWay) append(" (${serviceHour.busDirection.text})")
+                    },
                     style = defaultTeam6Typography.bodyRegular14,
                     color = defaultTeam6Colors.white
                 )
@@ -136,26 +154,71 @@ fun BusOperationInfoView(
             modifier = horizontalModifier
         )
         Spacer(modifier = Modifier.height(6.dp))
+
         Row(
-            modifier = horizontalModifier,
-            verticalAlignment = Alignment.CenterVertically
+            modifier = horizontalModifier
         ) {
-            busOperationInfo.serviceHours.forEachIndexed { index, serviceHour ->
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = serviceHour.dailyType,
-                        style = defaultTeam6Typography.bodyRegular13,
-                        color = defaultTeam6Colors.gray200
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text(
-                        text = "${serviceHour.term}분",
-                        style = defaultTeam6Typography.bodyRegular14,
-                        color = defaultTeam6Colors.white
-                    )
+            if (!isOneWay) {
+                Text(
+                    text = "상행",
+                    style = defaultTeam6Typography.bodyRegular14,
+                    color = defaultTeam6Colors.white
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+            }
+
+            FlowRow(
+                mainAxisSpacing = 15.dp,
+                crossAxisSpacing = 8.dp
+            ) {
+                upList.forEach { serviceHour ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = serviceHour.dailyType,
+                            style = defaultTeam6Typography.bodyRegular13,
+                            color = defaultTeam6Colors.gray200
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = "${serviceHour.term}분",
+                            style = defaultTeam6Typography.bodyRegular14,
+                            color = defaultTeam6Colors.white
+                        )
+                    }
                 }
-                if (index != busOperationInfo.serviceHours.lastIndex) {
-                    Spacer(modifier = Modifier.width(15.dp))
+            }
+        }
+
+        Row(
+            modifier = horizontalModifier
+        ) {
+            if (!isOneWay) {
+                Text(
+                    text = "하행",
+                    style = defaultTeam6Typography.bodyRegular14,
+                    color = defaultTeam6Colors.white
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+            }
+
+            FlowRow(
+                mainAxisSpacing = 15.dp,
+                crossAxisSpacing = 8.dp
+            ) {
+                downList.forEach { serviceHour ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = serviceHour.dailyType,
+                            style = defaultTeam6Typography.bodyRegular13,
+                            color = defaultTeam6Colors.gray200
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = "${serviceHour.term}분",
+                            style = defaultTeam6Typography.bodyRegular14,
+                            color = defaultTeam6Colors.white
+                        )
+                    }
                 }
             }
         }
@@ -169,7 +232,7 @@ fun BusOperationInfoView(
             )
             Spacer(modifier = Modifier.width(4.dp))
             Text(
-                text = "버스 정보는 운행상황 및 운수사의 정책에 따라 실제와 다를 수 있습니다.",
+                text = "운행상황 및 운수사의 정책에 따라 실제와 다를 수 있습니다.",
                 style = defaultTeam6Typography.bodyRegular11,
                 color = defaultTeam6Colors.gray200
             )
@@ -177,13 +240,13 @@ fun BusOperationInfoView(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun BusOperationInfoPreview() {
     BusOperationInfoView(
         busOperationInfo = BusOperationInfo(
-            startStationName = "복정역환승센터",
-            endStationName = "노들역",
+            startStationName = "수원버스터미널",
+            endStationName = "강남역나라빌딩앞",
             serviceHours = emptyList()
         ),
         busNumber = "350",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanistFlowlayout = "0.36.0"
 accompanistSystemuicontroller = "0.30.1"
 accompanistWebview = "0.24.13-rc"
 agp = "8.7.0"
@@ -44,6 +45,7 @@ timber = "5.0.1"
 runtimeLivedata = "1.7.8"
 
 [libraries]
+accompanist-flowlayout = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanistFlowlayout" }
 accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemuicontroller" }
 accompanist-webview = { module = "com.google.accompanist:accompanist-webview", version.ref = "accompanistWebview" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closed #213 

## 📝작업 내용

 기존에 버스 운행이 단방향이 아닌경우에 대해 처리가 되어있지 않아 발생하던 UI 문제를 해결하였습니다.


## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)
Before | After
:--: | :--:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/419870e1-8b87-4156-999e-dcaf1b842e44" /> | <img src="https://github.com/user-attachments/assets/581b9b92-895a-4c39-baac-fd56e3960f3b" width="300" />

No Direction | 
:--: | 
단방향일 경우 운행방향 표시 X (기존로직)
<img width="300" alt="Screenshot_20250902_002018" src="https://github.com/user-attachments/assets/1427efed-f45f-472f-a5cf-a88424ba3605" />|



## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 서버 측에 물어보니 단방향일인 버스의 busDirection은 UP으로 내려준다고 합니다