### PR TITLE
[#238] 설정 마커랑 현위치 마커 안겹침 현상

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/component/MapView.kt
@@ -141,6 +141,7 @@ fun TMapViewCompose(
                 if (isMapFocused) {
                     tMapView.setCenterPoint(currentLocation.latitude, currentLocation.longitude)
                     getCenterLocation(LatLng(currentLocation.latitude, currentLocation.longitude)) // 필요없어보여서 주석처리 해뒀어요
+                    tMapView.zoomLevel = 18
 
                     AmplitudeUtils.trackEventWithProperties(
                         eventName = HOME_EVENT_COURSESEARCH_ENTERED,

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/component/MypageMapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/component/MypageMapView.kt
@@ -63,7 +63,7 @@ fun MypageMapView(
 
     val tMapView = remember { TMapView(context) }
     var isMapReady by remember { mutableStateOf(false) }
-    val offsetLat = 0.00005
+    val offsetLat = 0.00009
     val coroutineScope = rememberCoroutineScope()
 
     BackHandler {
@@ -118,7 +118,7 @@ fun MypageMapView(
                         id = "CurrentMarker"
                         name = "Current Location"
                         icon = markerBitmap
-                        setTMapPoint(TMapPoint(currentLocation.latitude, currentLocation.longitude))
+                        tMapPoint = TMapPoint(currentLocation.latitude, currentLocation.longitude)
                     }
 
                     tMapView.addTMapMarkerItem(markerItem)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #238 

## 📝작업 내용
- 설정 마커랑 현위치 마커 안겹침 현상 수정

## PR 발행 전 체크 리스트

- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인
- [ ] 코드 린트 확인

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 선택한 주소를 기준으로 한 지도 중심 위치 계산을 개선하여 표시 정확도를 높였습니다.
  * 포커스된 지도에서 자동으로 확대(줌 레벨 18)가 적용되어 원하는 위치를 더 선명하게 볼 수 있습니다.
  * 현재 위치 마커 표시 방식을 최적화해 마커 위치 안정성과 신뢰성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->