### PR TITLE
[#240] 출발지 검색 시 지도 검색 추가

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationContract.kt
@@ -9,8 +9,13 @@ import com.depromeet.team6.presentation.util.base.UiState
 import com.depromeet.team6.presentation.util.view.LoadState
 
 class SearchLocationContract {
+    enum class SearchLocationScreen {
+        LISTVIEW, MAPVIEW
+    }
+
     data class SearchLocationUiState(
         val loadState: LoadState = LoadState.Idle,
+        val currentScreen: SearchLocationScreen = SearchLocationScreen.LISTVIEW,
         val userLocation: LoadState = LoadState.Idle,
         val searchQuery: String = "",
         val searchResults: List<Location> = emptyList(),

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationContract.kt
@@ -20,7 +20,6 @@ class SearchLocationContract {
         val searchQuery: String = "",
         val searchResults: List<Location> = emptyList(),
         val recentSearches: List<Location> = emptyList(),
-        val searchSelectMapView: Boolean = false,
         val selectLocation: Address = Address(
             name = "",
             lat = 0.0,
@@ -58,6 +57,6 @@ class SearchLocationContract {
 
         data class UpdateUserLocationSate(val userLocation: LoadState) : SearchLocationEvent()
 
-        data class ChangeSearchSelectMapViewVisible(val searchSelectMapView: Boolean) : SearchLocationEvent()
+        data class ChangeCurrentScreen(val screen: SearchLocationScreen) : SearchLocationEvent()
     }
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
@@ -151,7 +151,7 @@ fun SearchLocationRoute(
 
     when (uiState.loadState) {
         LoadState.Idle, LoadState.Loading, LoadState.Success -> {
-            when(uiState.currentScreen) {
+            when (uiState.currentScreen) {
                 SearchLocationContract.SearchLocationScreen.LISTVIEW -> {
                     SearchLocationScreen(
                         context = context,
@@ -245,7 +245,7 @@ fun SearchLocationRoute(
                             )
                         },
                         getCenterLocation = { viewModel.getCenterLocation(it) },
-                        onMapButtonClicked = { viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(true))}
+                        onMapButtonClicked = { viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(true)) }
                     )
                 }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
@@ -220,9 +220,13 @@ fun SearchLocationRoute(
                             // 최근 검색 내역 추가
                             viewModel.postSearchHistory(searchHistory)
                         },
-                        onMapButtonClicked = { viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ChangeCurrentScreen(
-                            SearchLocationContract.SearchLocationScreen.MAPVIEW
-                        )) }
+                        onMapButtonClicked = {
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.ChangeCurrentScreen(
+                                    SearchLocationContract.SearchLocationScreen.MAPVIEW
+                                )
+                            )
+                        }
                     )
                 }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
@@ -151,99 +151,137 @@ fun SearchLocationRoute(
 
     when (uiState.loadState) {
         LoadState.Idle, LoadState.Loading, LoadState.Success -> {
-            SearchLocationScreen(
-                context = context,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(defaultTeam6Colors.gray950)
-                    .padding(
-                        paddingValues = PaddingValues(
-                            start = padding.calculateStartPadding(LocalLayoutDirection.current),
-                            end = padding.calculateEndPadding(LocalLayoutDirection.current),
-                            top = 0.dp,
-                            bottom = padding.calculateBottomPadding()
-                        )
-                    ),
-                marginTop = padding.calculateTopPadding(),
-                viewModel = viewModel,
-                backButtonClick = navigateToBack,
-                location = userLocation,
-                uiState = uiState,
-                searchText = uiState.searchQuery,
-                onSearchTextChange = { newText ->
-                    viewModel.setState {
-                        copy(searchQuery = newText)
-                    }
-                    viewModel.setEvent(
-                        SearchLocationContract.SearchLocationEvent.UpdateSearchQuery(
-                            text = newText,
-                            lat = userLocation.latitude,
-                            lon = userLocation.longitude
-                        )
-                    )
-                },
-                onDeleteAllButtonClicked = { viewModel.deleteAllSearchHistory() },
-                onDeleteButtonClicked =
-                { searchHistory -> // 검색 내역 삭제
-                    viewModel.deleteSearchHistory(
-                        searchHistory = searchHistory,
-                        location = userLocation
-                    )
-                },
-                selectButtonClicked = { searchHistory -> // 장소 선택
-                    // 장소 텍스트 검색
-                    viewModel.setState {
-                        copy(searchQuery = searchHistory.name)
-                    }
-                    viewModel.setState {
-                        copy(
-                            selectLocation = Address(
-                                searchHistory.name,
-                                searchHistory.lat,
-                                searchHistory.lon,
-                                searchHistory.address
+            when(uiState.currentScreen) {
+                SearchLocationContract.SearchLocationScreen.LISTVIEW -> {
+                    SearchLocationScreen(
+                        context = context,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(defaultTeam6Colors.gray950)
+                            .padding(
+                                paddingValues = PaddingValues(
+                                    start = padding.calculateStartPadding(LocalLayoutDirection.current),
+                                    end = padding.calculateEndPadding(LocalLayoutDirection.current),
+                                    top = 0.dp,
+                                    bottom = padding.calculateBottomPadding()
+                                )
+                            ),
+                        marginTop = padding.calculateTopPadding(),
+                        viewModel = viewModel,
+                        backButtonClick = navigateToBack,
+                        location = userLocation,
+                        uiState = uiState,
+                        searchText = uiState.searchQuery,
+                        onSearchTextChange = { newText ->
+                            viewModel.setState {
+                                copy(searchQuery = newText)
+                            }
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.UpdateSearchQuery(
+                                    text = newText,
+                                    lat = userLocation.latitude,
+                                    lon = userLocation.longitude
+                                )
                             )
-                        )
-                    }
-                    viewModel.setEvent(
-                        SearchLocationContract.SearchLocationEvent.UpdateSearchQuery(
-                            text = searchHistory.name,
-                            lat = userLocation.latitude,
-                            lon = userLocation.longitude
-                        )
-                    )
-                    viewModel.setEvent(
-                        SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                            true
-                        )
-                    )
-                    // 최근 검색 내역 추가
-                    viewModel.postSearchHistory(searchHistory)
-                },
-                navigateToCourseSearch = {
-                    viewModel.setEvent(
-                        SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                            false
-                        )
-                    )
+                        },
+                        onDeleteAllButtonClicked = { viewModel.deleteAllSearchHistory() },
+                        onDeleteButtonClicked =
+                        { searchHistory -> // 검색 내역 삭제
+                            viewModel.deleteSearchHistory(
+                                searchHistory = searchHistory,
+                                location = userLocation
+                            )
+                        },
+                        selectButtonClicked = { searchHistory -> // 장소 선택
+                            // 장소 텍스트 검색
+                            viewModel.setState {
+                                copy(searchQuery = searchHistory.name)
+                            }
+                            viewModel.setState {
+                                copy(
+                                    selectLocation = Address(
+                                        searchHistory.name,
+                                        searchHistory.lat,
+                                        searchHistory.lon,
+                                        searchHistory.address
+                                    )
+                                )
+                            }
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.UpdateSearchQuery(
+                                    text = searchHistory.name,
+                                    lat = userLocation.latitude,
+                                    lon = userLocation.longitude
+                                )
+                            )
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
+                                    true
+                                )
+                            )
+                            // 최근 검색 내역 추가
+                            viewModel.postSearchHistory(searchHistory)
+                        },
+                        navigateToCourseSearch = {
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
+                                    false
+                                )
+                            )
 
-                    val currentLocationJSON = Gson().toJson(uiState.selectLocation)
-                    val destinationPointJSON = Gson().toJson(destinationLocation)
-                    navigateToCourseSearch(
-                        currentLocationJSON,
-                        destinationPointJSON
+                            val currentLocationJSON = Gson().toJson(uiState.selectLocation)
+                            val destinationPointJSON = Gson().toJson(destinationLocation)
+                            navigateToCourseSearch(
+                                currentLocationJSON,
+                                destinationPointJSON
+                            )
+                        },
+                        clearAddress = {
+                            viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ClearText)
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
+                                    searchSelectMapView = false
+                                )
+                            )
+                        },
+                        getCenterLocation = { viewModel.getCenterLocation(it) },
+                        onMapButtonClicked = { viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(true))}
                     )
-                },
-                clearAddress = {
-                    viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ClearText)
-                    viewModel.setEvent(
-                        SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                            searchSelectMapView = false
-                        )
+                }
+
+                SearchLocationContract.SearchLocationScreen.MAPVIEW -> {
+                    SearchLocationMapView(
+                        marginTop = padding.calculateTopPadding(),
+                        context = context,
+                        myAddress = uiState.selectLocation,
+                        getCenterLocation = { viewModel.getCenterLocation(it) },
+                        currentLocation = userLocation,
+                        setDepartureButtonClicked = {
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
+                                    false
+                                )
+                            )
+
+                            val currentLocationJSON = Gson().toJson(uiState.selectLocation)
+                            val destinationPointJSON = Gson().toJson(destinationLocation)
+                            navigateToCourseSearch(
+                                currentLocationJSON,
+                                destinationPointJSON
+                            )
+                        },
+                        backButtonClicked = {
+                            viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ClearText)
+                            viewModel.setEvent(
+                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
+                                    searchSelectMapView = false
+                                )
+                            )
+                        }
                     )
-                },
-                getCenterLocation = { viewModel.getCenterLocation(it) }
-            )
+                }
+            }
+
             if (uiState.loadState == LoadState.Loading) {
                 AtChaLoadingView()
             }
@@ -269,7 +307,8 @@ fun SearchLocationScreen(
     selectButtonClicked: (Location) -> Unit = {},
     navigateToCourseSearch: () -> Unit = {},
     clearAddress: () -> Unit = {},
-    getCenterLocation: (LatLng) -> Unit = {}
+    getCenterLocation: (LatLng) -> Unit = {},
+    onMapButtonClicked: () -> Unit = {}
 ) {
     // 포커스를 제어하기 위한 focusManager
     val focusManager = LocalFocusManager.current
@@ -313,7 +352,7 @@ fun SearchLocationScreen(
                     viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ClearText)
                     viewModel.updateRecentSearches(location = location)
                 },
-                onMapButtonClicked = {} // TODO : 지도 연결 필요
+                onMapButtonClicked = onMapButtonClicked
             )
 
             TextFieldLocation(

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationScreen.kt
@@ -1,6 +1,5 @@
 package com.depromeet.team6.presentation.ui.searchlocation
 
-import android.content.Context
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -154,7 +153,6 @@ fun SearchLocationRoute(
             when (uiState.currentScreen) {
                 SearchLocationContract.SearchLocationScreen.LISTVIEW -> {
                     SearchLocationScreen(
-                        context = context,
                         modifier = Modifier
                             .fillMaxSize()
                             .background(defaultTeam6Colors.gray950)
@@ -215,37 +213,16 @@ fun SearchLocationRoute(
                                 )
                             )
                             viewModel.setEvent(
-                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                                    true
+                                SearchLocationContract.SearchLocationEvent.ChangeCurrentScreen(
+                                    SearchLocationContract.SearchLocationScreen.MAPVIEW
                                 )
                             )
                             // 최근 검색 내역 추가
                             viewModel.postSearchHistory(searchHistory)
                         },
-                        navigateToCourseSearch = {
-                            viewModel.setEvent(
-                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                                    false
-                                )
-                            )
-
-                            val currentLocationJSON = Gson().toJson(uiState.selectLocation)
-                            val destinationPointJSON = Gson().toJson(destinationLocation)
-                            navigateToCourseSearch(
-                                currentLocationJSON,
-                                destinationPointJSON
-                            )
-                        },
-                        clearAddress = {
-                            viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ClearText)
-                            viewModel.setEvent(
-                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                                    searchSelectMapView = false
-                                )
-                            )
-                        },
-                        getCenterLocation = { viewModel.getCenterLocation(it) },
-                        onMapButtonClicked = { viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(true)) }
+                        onMapButtonClicked = { viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ChangeCurrentScreen(
+                            SearchLocationContract.SearchLocationScreen.MAPVIEW
+                        )) }
                     )
                 }
 
@@ -258,8 +235,8 @@ fun SearchLocationRoute(
                         currentLocation = userLocation,
                         setDepartureButtonClicked = {
                             viewModel.setEvent(
-                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                                    false
+                                SearchLocationContract.SearchLocationEvent.ChangeCurrentScreen(
+                                    SearchLocationContract.SearchLocationScreen.LISTVIEW
                                 )
                             )
 
@@ -273,8 +250,8 @@ fun SearchLocationRoute(
                         backButtonClicked = {
                             viewModel.setEvent(SearchLocationContract.SearchLocationEvent.ClearText)
                             viewModel.setEvent(
-                                SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible(
-                                    searchSelectMapView = false
+                                SearchLocationContract.SearchLocationEvent.ChangeCurrentScreen(
+                                    SearchLocationContract.SearchLocationScreen.LISTVIEW
                                 )
                             )
                         }
@@ -294,7 +271,6 @@ fun SearchLocationRoute(
 @Composable
 fun SearchLocationScreen(
     marginTop: Dp,
-    context: Context = LocalContext.current,
     modifier: Modifier = Modifier,
     viewModel: SearchLocationViewModel = hiltViewModel(),
     backButtonClick: () -> Unit,
@@ -305,9 +281,6 @@ fun SearchLocationScreen(
     onDeleteButtonClicked: (Location) -> Unit = {},
     onDeleteAllButtonClicked: () -> Unit = {},
     selectButtonClicked: (Location) -> Unit = {},
-    navigateToCourseSearch: () -> Unit = {},
-    clearAddress: () -> Unit = {},
-    getCenterLocation: (LatLng) -> Unit = {},
     onMapButtonClicked: () -> Unit = {}
 ) {
     // 포커스를 제어하기 위한 focusManager
@@ -411,19 +384,6 @@ fun SearchLocationScreen(
                     }
                 }
             }
-        }
-
-        if (uiState.searchSelectMapView) {
-//            val currentLocation by remember { mutableStateOf(uiState.selectLocation) }
-            SearchLocationMapView(
-                marginTop = marginTop,
-                context = context,
-                myAddress = uiState.selectLocation,
-                getCenterLocation = getCenterLocation,
-                currentLocation = location,
-                setDepartureButtonClicked = navigateToCourseSearch,
-                backButtonClicked = clearAddress
-            )
         }
     }
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/SearchLocationViewModel.kt
@@ -87,8 +87,8 @@ class SearchLocationViewModel @Inject constructor(
 
             is SearchLocationContract.SearchLocationEvent.UpdateUserLocationSate -> setState { copy(userLocation = event.userLocation) }
 
-            is SearchLocationContract.SearchLocationEvent.ChangeSearchSelectMapViewVisible -> setState {
-                copy(searchSelectMapView = event.searchSelectMapView)
+            is SearchLocationContract.SearchLocationEvent.ChangeCurrentScreen -> setState {
+                copy(currentScreen = event.screen)
             }
         }
     }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/component/SearchLocationMapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/component/SearchLocationMapView.kt
@@ -72,7 +72,7 @@ fun SearchLocationMapView(
 
     val tMapView = remember { TMapView(context) }
     var isMapReady by remember { mutableStateOf(false) }
-    val offsetLat = 0.00005
+    val offsetLat = 0.00009
     val coroutineScope = rememberCoroutineScope()
 
     // Lifecycle 제어: ON_START 이후에만 지도 초기화
@@ -112,10 +112,13 @@ fun SearchLocationMapView(
                     }
                 }
 
-                val lat = myAddress.lat - offsetLat
-                val lon = myAddress.lon
+                val tMapPoint = TMapPoint(currentLocation.latitude, currentLocation.longitude)
+                tMapView.setCenterPoint(
+                    tMapPoint.latitude - offsetLat,
+                    tMapPoint.longitude
+                )
+                getCenterLocation(LatLng(tMapPoint.latitude, tMapPoint.longitude))
 
-                tMapView.setCenterPoint(lat, lon, true)
                 tMapView.zoomLevel = 18
 
                 val markerDrawable =
@@ -149,11 +152,12 @@ fun SearchLocationMapView(
             )
         }
 
-        // 뒤로가기 아이콘
-        CircleBtnBack(
+        // 뒤로가기
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_all_arrow_left_white),
+            contentDescription = stringResource(R.string.home_search_back_text),
+            tint = defaultTeam6Colors.gray300,
             modifier = Modifier
-                .size(36.dp)
-                .align(Alignment.TopStart)
                 .offset(x = 16.dp, y = 12.dp + marginTop)
                 .noRippleClickable {
                     backButtonClicked()
@@ -182,7 +186,8 @@ fun SearchLocationMapView(
                         .align(Alignment.BottomEnd)
                         .padding(end = 16.dp, bottom = 16.dp)
                         .clickable(enabled = isMapReady) {
-                            val tMapPoint = TMapPoint(currentLocation.latitude, currentLocation.longitude)
+                            val tMapPoint =
+                                TMapPoint(currentLocation.latitude, currentLocation.longitude)
                             tMapView.setCenterPoint(
                                 tMapPoint.latitude - offsetLat,
                                 tMapPoint.longitude
@@ -233,27 +238,6 @@ fun startScrollIdleCheck(
         }
 
         getCenterLocation(previousLatLng!!)
-    }
-}
-
-@Composable
-private fun CircleBtnBack(
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .roundedBackgroundWithPadding(
-                cornerRadius = 100.dp,
-                backgroundColor = defaultTeam6Colors.gray940
-            ),
-        contentAlignment = Alignment.Center
-    ) {
-        Image(
-            modifier = Modifier.size(20.dp),
-            imageVector = ImageVector.vectorResource(R.drawable.ic_all_arrow_left_grey),
-            colorFilter = ColorFilter.tint(defaultTeam6Colors.white),
-            contentDescription = "ItineraryCircleBtnBack"
-        )
     }
 }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/component/SearchLocationMapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/component/SearchLocationMapView.kt
@@ -1,7 +1,6 @@
 package com.depromeet.team6.presentation.ui.searchlocation.component
 
 import android.content.Context
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -21,7 +19,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -44,7 +41,6 @@ import com.depromeet.team6.domain.model.Address
 import com.depromeet.team6.presentation.ui.common.bottomsheet.AtChaLocationSettingBottomSheet
 import com.depromeet.team6.presentation.ui.common.view.AtChaLoadingView
 import com.depromeet.team6.presentation.util.modifier.noRippleClickable
-import com.depromeet.team6.presentation.util.modifier.roundedBackgroundWithPadding
 import com.depromeet.team6.ui.theme.defaultTeam6Colors
 import com.google.android.gms.maps.model.LatLng
 import com.skt.tmap.TMapPoint

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/component/SearchLocationMapView.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/searchlocation/component/SearchLocationMapView.kt
@@ -108,12 +108,14 @@ fun SearchLocationMapView(
                     }
                 }
 
-                val tMapPoint = TMapPoint(currentLocation.latitude, currentLocation.longitude)
-                tMapView.setCenterPoint(
-                    tMapPoint.latitude - offsetLat,
-                    tMapPoint.longitude
-                )
-                getCenterLocation(LatLng(tMapPoint.latitude, tMapPoint.longitude))
+                val (lat, lon) = if (myAddress.lat == 0.0 && myAddress.lon == 0.0) {
+                    currentLocation.latitude - offsetLat to currentLocation.longitude
+                } else {
+                    myAddress.lat - offsetLat to myAddress.lon
+                }
+
+                tMapView.setCenterPoint(lat, lon, true)
+                getCenterLocation(LatLng(lat, lon))
 
                 tMapView.zoomLevel = 18
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #240 

## 📝작업 내용

- 기존엔 출발지 검색 시 텍스트 검색만 구현하였는데 지도 검색을 추가하였습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인
- [x] 코드 린트 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/ee25cbdd-3e7e-4f84-bbba-3ac288944309

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 위치 검색 화면에서 리스트 뷰와 지도 뷰를 명확히 전환하는 화면 기반 흐름 추가
  * 지도 뷰에서 지도 버튼으로 맵 전환 가능하도록 콜백 제공
* **개선**
  * 지도 초기 중심 좌표 계산 로직 및 중심 오프셋 조정(보다 적절한 시각화)
  * 뒤로 가기 버튼을 이미지에서 벡터 아이콘으로 교체해 상호작용 개선
  * 장소 선택 시 내비게이션에 위치 데이터를 명확히 전달하도록 데이터 흐름 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->