### PR TITLE
[#245] 버전 업데이트 파싱 에러 수정

### DIFF
--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeContract.kt
@@ -82,6 +82,9 @@ class HomeContract {
         data class NavigateToItinerary(val markerParameter: FocusedMarkerParameter?) : HomeSideEffect
         data object ShowDeleteAlarmToast : HomeSideEffect
         data class ShowToast(val message: String) : HomeSideEffect
+
+        data object ShowUpdateRequiredDialog : HomeSideEffect
+        data object ShowUpdateOptionalDialog : HomeSideEffect
     }
 
     sealed class HomeEvent : UiEvent {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeScreen.kt
@@ -1,6 +1,8 @@
 package com.depromeet.team6.presentation.ui.home
 
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -34,6 +36,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -56,6 +59,7 @@ import com.depromeet.team6.presentation.ui.home.component.TMapViewCompose
 import com.depromeet.team6.presentation.ui.home.component.UnifiedCharacterBubble
 import com.depromeet.team6.presentation.util.AmplitudeCommon.SCREEN_NAME
 import com.depromeet.team6.presentation.util.AmplitudeCommon.USER_ID
+import com.depromeet.team6.presentation.util.AppConstants
 import com.depromeet.team6.presentation.util.HomeAmplitude.ALERT_END_POPUP_1
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME
 import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_COURSESEARCH_ENTERED_DIRECT
@@ -68,6 +72,7 @@ import com.depromeet.team6.presentation.util.HomeAmplitude.HOME_ROUTE_CLICKED
 import com.depromeet.team6.presentation.util.HomeAmplitude.POPUP
 import com.depromeet.team6.presentation.util.amplitude.AmplitudeUtils
 import com.depromeet.team6.presentation.util.base.ApiErrorSideEffect
+import com.depromeet.team6.presentation.util.dialog.DialogController
 import com.depromeet.team6.presentation.util.modifier.noRippleClickable
 import com.depromeet.team6.presentation.util.toast.atChaToastMessage
 import com.depromeet.team6.presentation.util.view.LoadState
@@ -89,20 +94,21 @@ import java.util.Locale
 @Composable
 fun HomeRoute(
     padding: PaddingValues,
-    afterOnboarding: Boolean = false,
     navigateToLogin: () -> Unit,
     navigateToCourseSearch: (String, String) -> Unit,
     navigateToMypage: () -> Unit,
     navigateToItinerary: (String, String, String, FocusedMarkerParameter?) -> Unit,
     navigateToSearchLocation: (Address) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: HomeViewModel = hiltViewModel()
+    viewModel: HomeViewModel = hiltViewModel(),
+    afterOnboarding: Boolean = false
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
 
     val systemUiController = rememberSystemUiController()
+    val dialogController = remember { DialogController() }
 
     val characterTexts = CharacterTexts(
         taxiCostText = stringResource(R.string.home_bubble_basic_text),
@@ -170,6 +176,7 @@ fun HomeRoute(
                     is ApiErrorSideEffect.ShowToastSideEffect -> {
                         Toast.makeText(context, sideEffect.toastMessage, Toast.LENGTH_SHORT).show()
                     }
+
                     is ApiErrorSideEffect.NavigateToLoginSideEffect -> navigateToLogin()
                     is HomeContract.HomeSideEffect.NavigateToMypage -> navigateToMypage()
                     is HomeContract.HomeSideEffect.NavigateToItinerary -> navigateToItinerary(
@@ -178,8 +185,26 @@ fun HomeRoute(
                         Gson().toJson(uiState.destinationPoint),
                         sideEffect.markerParameter
                     )
+
                     is HomeContract.HomeSideEffect.ShowDeleteAlarmToast ->
                         atChaToastMessage(context, R.string.home_alarm_finish_text, Toast.LENGTH_SHORT)
+
+                    is HomeContract.HomeSideEffect.ShowUpdateRequiredDialog -> {
+                        dialogController.showAtchaOneButtonAlert(
+                            message = "더 좋아진 앗차를 사용하기 위해\n업데이트가 필요해요",
+                            onConfirm = { openPlayStoreForUpdate(context = context) },
+                            confirmButtonText = "업데이트 하기"
+                        )
+                    }
+
+                    is HomeContract.HomeSideEffect.ShowUpdateOptionalDialog -> {
+                        dialogController.showAtchaTwoButtonAlert(
+                            message = "더 좋아진 앗차를 사용하기 위해\n업데이트가 필요해요",
+                            onConfirm = { openPlayStoreForUpdate(context = context) },
+                            confirmButtonText = "업데이트 하기",
+                            closeButtonText = "닫기"
+                        )
+                    }
                 }
             }
     }
@@ -189,17 +214,6 @@ fun HomeRoute(
             viewModel.registerAlarm()
         }
     }
-
-//    SideEffect {
-//        if (!PermissionUtil.isLocationPermissionRequested(context) &&
-//            !PermissionUtil.hasLocationPermissions(context)
-//        ) {
-//            PermissionUtil.requestLocationPermissions(
-//                context = context,
-//                locationPermissionLauncher = locationPermissionsLauncher
-//            )
-//        }
-//    }
 
     LaunchedEffect(Unit) {
         viewModel.setEvent(HomeContract.HomeEvent.SetDestination)
@@ -260,6 +274,7 @@ fun HomeRoute(
             uiState.isAlarmRegistered && !uiState.userDeparture && !uiState.isBusDeparted -> {
                 "before_bus_arrived"
             }
+
             uiState.isAlarmRegistered && !uiState.userDeparture -> {
                 if (uiState.firtTransportTation == TransportType.SUBWAY) {
                     "after_subway_arrived"
@@ -267,10 +282,13 @@ fun HomeRoute(
                     "after_bus_arrived"
                 }
             }
+
             uiState.isAlarmRegistered && !uiState.timerFinish && uiState.firtTransportTation == TransportType.BUS ->
                 "after_user_departure_bus"
+
             uiState.isAlarmRegistered && !uiState.timerFinish && uiState.firtTransportTation == TransportType.SUBWAY ->
                 "after_user_departure_subway"
+
             else -> "none"
         }
     }
@@ -429,18 +447,22 @@ fun HomeRoute(
             isShowingFirstTimeMessage -> {
                 // 첫 번째 메시지 표시 중이면 아무것도 하지 않음
             }
+
             hideBubbleAfterComponentClick -> {
                 hideBubbleAfterComponentClick = false
                 animationTrigger += 1
             }
+
             hideDefaultBubbleAfterFirstMessage -> {
                 hideDefaultBubbleAfterFirstMessage = false
                 animationTrigger += 1
             }
+
             tempSpeechBubble == null && characterState.speechTexts.size > 1 -> {
                 currentSpeechIndex = (currentSpeechIndex + 1) % characterState.speechTexts.size
                 animationTrigger += 1
             }
+
             tempSpeechBubble == null -> {
                 animationTrigger += 1
             }
@@ -451,6 +473,7 @@ fun HomeRoute(
         LoadState.Idle, LoadState.Loading -> {
             AtChaLoadingView()
         }
+
         LoadState.Success -> {
             Box {
                 if (uiState.alarmCheckLoadState == LoadState.Loading ||
@@ -1023,6 +1046,29 @@ private fun generateCharacterStateWithLaunchCount(
                 bottomPadding = 194.dp
             )
         }
+    }
+}
+
+private fun openPlayStoreForUpdate(context: Context) {
+    val packageName = AppConstants.PLAY_STORE_PACKAGE_NAME
+
+    try {
+        val intent = Intent(
+            Intent.ACTION_VIEW,
+            "market://details?id=$packageName".toUri()
+        ).apply {
+            setPackage("com.android.vending")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    } catch (_: ActivityNotFoundException) {
+        val webIntent = Intent(
+            Intent.ACTION_VIEW,
+            AppConstants.PLAY_STORE_URL.toUri()
+        ).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(webIntent)
     }
 }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import com.depromeet.team6.domain.repository.HomeRepository
 import com.depromeet.team6.domain.repository.UserInfoRepository
 import com.depromeet.team6.domain.usecase.DeleteAlarmUseCase
 import com.depromeet.team6.domain.usecase.GetAddressFromCoordinatesUseCase
+import com.depromeet.team6.domain.usecase.GetAppVersionUseCase
 import com.depromeet.team6.domain.usecase.GetBusArrivalUseCase
 import com.depromeet.team6.domain.usecase.GetBusStartedUseCase
 import com.depromeet.team6.domain.usecase.GetCourseSearchResultsUseCase
@@ -62,6 +63,7 @@ class HomeViewModel @Inject constructor(
     private val deleteAlarmUseCase: DeleteAlarmUseCase,
     private val refreshAlarmTimerUseCase: RefreshAlarmTimerUseCase,
     private val getRealtimeLocationUseCase: GetRealtimeLocationUseCase,
+    private val getAppVersionUseCase: GetAppVersionUseCase,
     @ApplicationContext private val context: Context
 ) : BaseViewModel<HomeContract.HomeUiState, HomeContract.HomeSideEffect, HomeContract.HomeEvent>() {
     private var speechBubbleJob: Job? = null
@@ -69,6 +71,7 @@ class HomeViewModel @Inject constructor(
     private var lastRouteId: String = ""
 
     init {
+        checkAppVersion()
         showSpeechBubbleTemporarily()
         viewModelScope.launch {
             val currentLocation = withContext(Dispatchers.IO) {
@@ -113,6 +116,7 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+
             is HomeContract.HomeEvent.SetDestination -> setDestination()
             is HomeContract.HomeEvent.LoadLegsResult -> {
                 setState {
@@ -122,6 +126,7 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+
             is HomeContract.HomeEvent.LoadDepartureDateTime -> {
                 setState {
                     copy(
@@ -193,16 +198,19 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+
             HomeContract.HomeEvent.DeleteAlarmConfirmed -> setState {
                 copy(
                     deleteAlarmDialogVisible = false
                 )
             }
+
             HomeContract.HomeEvent.DismissDialog -> setState {
                 copy(
                     deleteAlarmDialogVisible = false
                 )
             }
+
             HomeContract.HomeEvent.FinishAlarmClicked -> {
                 setState { copy(deleteAlarmDialogVisible = true) }
             }
@@ -239,6 +247,7 @@ class HomeViewModel @Inject constructor(
                     )
                 )
             }
+
             is HomeContract.HomeEvent.CourseDetailButtonClick -> {
                 AmplitudeUtils.trackEventWithProperties(
                     eventName = HOME_EVENT_ITINERARY_BTN_CLICK,
@@ -273,6 +282,7 @@ class HomeViewModel @Inject constructor(
                     currentState.firstTransportationName.isNotEmpty() &&
                     currentState.itineraryInfo != null
             }
+
             else -> false
         }
 
@@ -514,7 +524,14 @@ class HomeViewModel @Inject constructor(
                 setEvent(HomeContract.HomeEvent.LoadLegsResult(courseInfo))
                 setEvent(HomeContract.HomeEvent.LoadDepartureDateTime(courseInfo.departureTime))
                 setEvent(HomeContract.HomeEvent.LoadBoardingDateTime(courseInfo.boardingTime))
-                setEvent(HomeContract.HomeEvent.LoadHomeArrivedTime(calculateArrivalTime(courseInfo.departureTime, courseInfo.totalTime)))
+                setEvent(
+                    HomeContract.HomeEvent.LoadHomeArrivedTime(
+                        calculateArrivalTime(
+                            courseInfo.departureTime,
+                            courseInfo.totalTime
+                        )
+                    )
+                )
                 setEvent(HomeContract.HomeEvent.LoadFirstTransportation(getFirstTransportation(courseInfo.legs)))
                 setEvent(HomeContract.HomeEvent.LoadFirstTransportationNumber(getFirstTransportationNumber(courseInfo.legs)))
                 setEvent(HomeContract.HomeEvent.LoadFirstTransportationName(getFirstTransportationName(courseInfo.legs)))
@@ -688,6 +705,70 @@ class HomeViewModel @Inject constructor(
             }.onFailure { exception ->
                 handleApiException(exception = exception)
             }
+        }
+    }
+
+    private fun checkAppVersion() {
+        val installedVersion = getCurrentVersionName()?.cleanVersion() ?: "0.0.0"
+        viewModelScope.launch {
+            getAppVersionUseCase().onSuccess { appVersion ->
+                val latestVersion = appVersion.removePrefix("Success(")
+                    .removePrefix("v")
+                    .removeSuffix(")")
+                    .cleanVersion()
+
+                Timber.d("latestVersion: $latestVersion, installedVersion: $installedVersion")
+
+                when (compareVersions(installedVersion, latestVersion)) {
+                    VersionResult.UPDATE_REQUIRED -> {
+                        setSideEffect(HomeContract.HomeSideEffect.ShowUpdateRequiredDialog)
+                    }
+
+                    VersionResult.UPDATE_OPTIONAL -> {
+                        setSideEffect(HomeContract.HomeSideEffect.ShowUpdateOptionalDialog)
+                    }
+
+                    VersionResult.UP_TO_DATE -> {
+                        Timber.d("최신 버전입니다")
+                    }
+                }
+            }.onFailure {
+                Timber.e(it, "앱 버전 확인 실패")
+            }
+        }
+    }
+
+    private fun String.cleanVersion(): String =
+        this.replace("[^0-9.]".toRegex(), "")
+
+    private fun compareVersions(installed: String, latest: String): VersionResult {
+        val installedParts = installed.split(".").map { it.toIntOrNull() ?: 0 }
+        val latestParts = latest.split(".").map { it.toIntOrNull() ?: 0 }
+
+        val (a1, b1, c1) = installedParts + List(3 - installedParts.size) { 0 }
+        val (a2, b2, c2) = latestParts + List(3 - latestParts.size) { 0 }
+
+        return when {
+            a1 != a2 -> if (a1 < a2) VersionResult.UPDATE_REQUIRED else VersionResult.UP_TO_DATE
+            b1 != b2 -> if (b1 < b2) VersionResult.UPDATE_REQUIRED else VersionResult.UP_TO_DATE
+            c1 != c2 -> if (c1 < c2) VersionResult.UPDATE_OPTIONAL else VersionResult.UP_TO_DATE
+            else -> VersionResult.UP_TO_DATE
+        }
+    }
+
+    private enum class VersionResult {
+        UPDATE_REQUIRED,
+        UPDATE_OPTIONAL,
+        UP_TO_DATE
+    }
+
+    private fun getCurrentVersionName(): String? {
+        return try {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            packageInfo.versionName
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to get app version name")
+            "0.0.0"
         }
     }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainActivity.kt
@@ -1,7 +1,5 @@
 package com.depromeet.team6.presentation.ui.main
 
-import android.content.ActivityNotFoundException
-import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
@@ -26,14 +24,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.app.ActivityCompat
-import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.flowWithLifecycle
 import com.depromeet.team6.R
 import com.depromeet.team6.presentation.ui.common.dialog.GlobalDialogHandler
 import com.depromeet.team6.presentation.ui.common.snackbar.GlobalSnackbarHandler
@@ -42,7 +37,6 @@ import com.depromeet.team6.presentation.ui.lock.LockScreenNavigator
 import com.depromeet.team6.presentation.ui.main.navigation.MainNavHost
 import com.depromeet.team6.presentation.ui.main.navigation.MainNavigator
 import com.depromeet.team6.presentation.ui.main.navigation.rememberMainNavigator
-import com.depromeet.team6.presentation.util.AppConstants
 import com.depromeet.team6.presentation.util.context.openAppSettings
 import com.depromeet.team6.presentation.util.dialog.DialogController
 import com.depromeet.team6.presentation.util.dialog.LocalDialogController
@@ -62,29 +56,6 @@ class MainActivity : ComponentActivity() {
     private var backPressedTime = 0L
 
     private lateinit var firebaseAnalytics: FirebaseAnalytics
-
-    private fun openPlayStoreForUpdate() {
-        try {
-            startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    "market://details?id=${AppConstants.PLAY_STORE_PACKAGE_NAME}".toUri()
-                ).apply {
-                    setPackage("com.android.vending")
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-            )
-        } catch (_: ActivityNotFoundException) {
-            startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    AppConstants.PLAY_STORE_URL.toUri()
-                ).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-            )
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -142,31 +113,7 @@ class MainActivity : ComponentActivity() {
                     isAppearanceLightNavigationBars = false
                 }
             }
-            val lifecycleOwner = LocalLifecycleOwner.current
 
-            LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
-                viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
-                    .collect { onboardingSideEffect ->
-                        when (onboardingSideEffect) {
-                            is MainContract.MainSideEffect.ShowUpdateRequiredDialog -> {
-                                dialogController.showAtchaOneButtonAlert(
-                                    message = "더 좋아진 앗차를 사용하기 위해\n업데이트가 필요해요",
-                                    onConfirm = { openPlayStoreForUpdate() },
-                                    confirmButtonText = "업데이트 하기"
-                                )
-                            }
-
-                            is MainContract.MainSideEffect.ShowUpdateOptionalDialog -> {
-                                dialogController.showAtchaTwoButtonAlert(
-                                    message = "더 좋아진 앗차를 사용하기 위해\n업데이트가 필요해요",
-                                    onConfirm = { openPlayStoreForUpdate() },
-                                    confirmButtonText = "업데이트 하기",
-                                    closeButtonText = "닫기"
-                                )
-                            }
-                        }
-                    }
-            }
             val locationPermissionsLauncher = rememberLauncherForActivityResult(
                 contract = ActivityResultContracts.RequestMultiplePermissions(),
                 onResult = { permissions ->
@@ -188,14 +135,22 @@ class MainActivity : ComponentActivity() {
                     dialogController.showAtchaTwoButtonAlert(
                         message = this@MainActivity.getString(R.string.all_dialog_location_permission),
                         onConfirm = {
-                            if (ActivityCompat.shouldShowRequestPermissionRationale(this@MainActivity, android.Manifest.permission.ACCESS_FINE_LOCATION)) {
+                            if (ActivityCompat.shouldShowRequestPermissionRationale(
+                                    this@MainActivity,
+                                    android.Manifest.permission.ACCESS_FINE_LOCATION
+                                )
+                            ) {
                                 this@MainActivity.openAppSettings()
                             } else {
-                                PermissionUtil.requestLocationPermissions(this@MainActivity, locationPermissionsLauncher)
+                                PermissionUtil.requestLocationPermissions(
+                                    this@MainActivity,
+                                    locationPermissionsLauncher
+                                )
                             }
                         },
                         onDismiss = {
-                            Toast.makeText(this@MainActivity, "앗차 앱을 사용하시기 전에 위치 권한을 허용해 주세요", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(this@MainActivity, "앗차 앱을 사용하시기 전에 위치 권한을 허용해 주세요", Toast.LENGTH_SHORT)
+                                .show()
                             exitProcess(0)
                         },
                         closeButtonText = "닫기",

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainContract.kt
@@ -15,10 +15,7 @@ class MainContract {
         val currentLocation: LatLng = LatLng(DEFAULT_LAT, DEFAULT_LNG)
     ) : UiState
 
-    sealed interface MainSideEffect : UiSideEffect {
-        data object ShowUpdateRequiredDialog : MainSideEffect
-        data object ShowUpdateOptionalDialog : MainSideEffect
-    }
+    sealed interface MainSideEffect : UiSideEffect
 
     sealed class MainEvent : UiEvent
 }

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/main/MainViewModel.kt
@@ -6,7 +6,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.domain.repository.UserInfoRepository
-import com.depromeet.team6.domain.usecase.GetAppVersionUseCase
 import com.depromeet.team6.domain.usecase.GetRealtimeLocationUseCase
 import com.depromeet.team6.presentation.util.base.BaseViewModel
 import com.depromeet.team6.presentation.util.view.LoadState
@@ -34,7 +33,6 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val userInfoRepository: UserInfoRepository,
-    private val getAppVersionUseCase: GetAppVersionUseCase,
     private val getRealtimeLocationUseCase: GetRealtimeLocationUseCase,
     @ApplicationContext private val context: Context
 ) : BaseViewModel<MainContract.MainState, MainContract.MainSideEffect, MainContract.MainEvent>() {
@@ -58,7 +56,6 @@ class MainViewModel @Inject constructor(
     init {
         loadInitialData()
         fetchFcmToken()
-        checkAppVersion()
     }
 
     override fun createInitialState(): MainContract.MainState = MainContract.MainState()
@@ -155,70 +152,6 @@ class MainViewModel @Inject constructor(
             } else {
                 Timber.e("Fetching FCM token failed")
             }
-        }
-    }
-
-    private fun checkAppVersion() {
-        val installedVersion = getCurrentVersionName()?.cleanVersion() ?: "0.0.0"
-        viewModelScope.launch {
-            getAppVersionUseCase().onSuccess { appVersion ->
-                val latestVersion = appVersion.removePrefix("Success(")
-                    .removePrefix("v")
-                    .removeSuffix(")")
-                    .cleanVersion()
-
-                Timber.d("latestVersion: $latestVersion, installedVersion: $installedVersion")
-
-                when (compareVersions(installedVersion, latestVersion)) {
-                    VersionResult.UPDATE_REQUIRED -> {
-                        setSideEffect(MainContract.MainSideEffect.ShowUpdateRequiredDialog)
-                    }
-
-                    VersionResult.UPDATE_OPTIONAL -> {
-                        setSideEffect(MainContract.MainSideEffect.ShowUpdateOptionalDialog)
-                    }
-
-                    VersionResult.UP_TO_DATE -> {
-                        Timber.d("최신 버전입니다")
-                    }
-                }
-            }.onFailure {
-                Timber.e(it, "앱 버전 확인 실패")
-            }
-        }
-    }
-
-    private fun String.cleanVersion(): String =
-        this.replace("[^0-9.]".toRegex(), "")
-
-    private fun compareVersions(installed: String, latest: String): VersionResult {
-        return VersionResult.UP_TO_DATE
-        val installedParts = installed.split(".").map { it.toIntOrNull() ?: 0 }
-        val latestParts = latest.split(".").map { it.toIntOrNull() ?: 0 }
-
-        val (a1, b1, c1) = installedParts + List(3 - installedParts.size) { 0 }
-        val (a2, b2, c2) = latestParts + List(3 - latestParts.size) { 0 }
-
-        return when {
-            a1 < a2 || b1 < b2 -> VersionResult.UPDATE_REQUIRED
-            c1 < c2 -> VersionResult.UPDATE_OPTIONAL
-            else -> VersionResult.UP_TO_DATE
-        }
-    }
-
-    private enum class VersionResult {
-        UPDATE_REQUIRED,
-        UPDATE_OPTIONAL,
-        UP_TO_DATE
-    }
-
-    private fun getCurrentVersionName(): String? {
-        return try {
-            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            packageInfo.versionName
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to get app version name")
-            "0.0.0"
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #245

## 📝작업 내용

앱 삭제 후 재설치시 토큰을 받아오기 전에 실행되어 빈 헤더로 요청하는 문제가 있었습니다.
- 설치버전, 최신 버전 비교 로직을 메인에서 홈으로 이동했습니다.

## PR 발행 전 체크 리스트
안해!
- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인
- [ ] 코드 린트 확인

## 스크린샷 (선택)
없어!

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - @hyuns66  우리 위치권한 팝업 로직도 수정해야될 것 같은데요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **앱 업데이트 알림**: 필수 업데이트와 선택 업데이트 알림이 홈 화면에 표시됩니다.
* **Play Store 연동**: 알림에서 Play Store로 직접 이동하여 앱을 업데이트할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->