### PR TITLE
[#262] 마이페이지 앱 버전 업데이트 버튼 노출 버그 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,6 +175,9 @@ dependencies {
     // Amplitude
     implementation(libs.amplitude)
     implementation(libs.play.services.appset)
+
+    // In-App Update
+    implementation(libs.app.update.ktx)
 }
 java {
     toolchain {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageContract.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageContract.kt
@@ -51,7 +51,8 @@ class MypageContract {
         ),
         val mapViewVisible: Boolean = false,
         val selectedAlarmType: AlarmType = AlarmType.SOUND,
-        val alarmVolume: Int = 50
+        val alarmVolume: Int = 50,
+        val isUpdateAvailable: Boolean = false
     ) : UiState
 
     sealed interface MypageSideEffect : UiSideEffect {

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageScreen.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageScreen.kt
@@ -34,7 +34,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
-import com.depromeet.team6.BuildConfig
 import com.depromeet.team6.R
 import com.depromeet.team6.presentation.ui.common.view.AtChaWebView
 import com.depromeet.team6.presentation.ui.mypage.component.MyPageConfirmDialog
@@ -121,6 +120,7 @@ fun MyPageRoute(
         if (!isInitialized["initialized"]!!) {
             mypageViewModel.getUserInfo()
             mypageViewModel.updateUserLocation(context)
+            mypageViewModel.checkUpdateAvailability(context)
             isInitialized["initialized"] = true
         }
     }
@@ -198,7 +198,7 @@ fun MyPageRoute(
                                     mypageViewModel.navigateToPlayStore(context)
                                 },
                                 onBannerClicked = { mypageViewModel.setSideEffect(MypageContract.MypageSideEffect.NavigateToFeedbackForm) },
-                                isUpdateBtnVisible = uiState.userInfo.appVersion != ("v" + BuildConfig.VERSION_NAME)
+                                isUpdateBtnVisible = uiState.isUpdateAvailable
                             )
                         }
 

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
@@ -5,11 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
-import com.depromeet.team6.BuildConfig
-import com.google.android.play.core.appupdate.AppUpdateManager
-import com.google.android.play.core.appupdate.AppUpdateManagerFactory
-import com.google.android.play.core.install.model.UpdateAvailability
 import androidx.lifecycle.viewModelScope
+import com.depromeet.team6.BuildConfig
 import com.depromeet.team6.data.dataremote.model.request.user.RequestModifyUserInfoDto
 import com.depromeet.team6.data.repositoryimpl.UserInfoRepositoryImpl
 import com.depromeet.team6.domain.model.Address
@@ -27,6 +24,9 @@ import com.depromeet.team6.presentation.util.context.getUserLocation
 import com.depromeet.team6.presentation.util.permission.PermissionUtil
 import com.depromeet.team6.presentation.util.view.LoadState
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.UpdateAvailability
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/depromeet/team6/presentation/ui/mypage/MypageViewModel.kt
@@ -4,6 +4,11 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
+import com.depromeet.team6.BuildConfig
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.UpdateAvailability
 import androidx.lifecycle.viewModelScope
 import com.depromeet.team6.data.dataremote.model.request.user.RequestModifyUserInfoDto
 import com.depromeet.team6.data.repositoryimpl.UserInfoRepositoryImpl
@@ -144,6 +149,7 @@ class MypageViewModel @Inject constructor(
 
         viewModelScope.launch {
             getUserInfoUseCase().onSuccess { userInfo ->
+                Log.d("MypageVM", "appVersion from server: ${userInfo.appVersion}")
                 setLocationToHomeAddress(userInfo.userHome.latitude, userInfo.userHome.longitude)
                 setState {
                     copy(
@@ -262,6 +268,28 @@ class MypageViewModel @Inject constructor(
             }
             context.startActivity(intent)
         }
+    }
+
+    fun checkUpdateAvailability(
+        context: Context,
+        appUpdateManager: AppUpdateManager = AppUpdateManagerFactory.create(context)
+    ) {
+        appUpdateManager.appUpdateInfo
+            .addOnSuccessListener { appUpdateInfo ->
+                val isUpdateAvailable = isUpdateAvailableFromPlayApi(appUpdateInfo.updateAvailability())
+                setState { copy(isUpdateAvailable = isUpdateAvailable) }
+            }
+            .addOnFailureListener {
+                fallbackToServerVersion()
+            }
+    }
+
+    private fun fallbackToServerVersion() {
+        val isUpdateAvailable = isUpdateAvailableFromServer(
+            serverVersion = currentState.userInfo.appVersion.orEmpty(),
+            currentVersion = BuildConfig.VERSION_NAME
+        )
+        setState { copy(isUpdateAvailable = isUpdateAvailable) }
     }
 
     private fun setLocationToHomeAddress(
@@ -469,5 +497,13 @@ class MypageViewModel @Inject constructor(
 //                navigateToMainSetting()
 //            }
 //        }
+    }
+
+    companion object {
+        internal fun isUpdateAvailableFromPlayApi(updateAvailability: Int): Boolean =
+            updateAvailability == UpdateAvailability.UPDATE_AVAILABLE
+
+        internal fun isUpdateAvailableFromServer(serverVersion: String, currentVersion: String): Boolean =
+            serverVersion.isNotEmpty() && serverVersion != "v$currentVersion"
     }
 }

--- a/app/src/test/java/com/depromeet/team6/MypageUpdateAvailabilityTest.kt
+++ b/app/src/test/java/com/depromeet/team6/MypageUpdateAvailabilityTest.kt
@@ -1,0 +1,87 @@
+package com.depromeet.team6
+
+import com.depromeet.team6.presentation.ui.mypage.MypageViewModel
+import com.google.android.play.core.install.model.UpdateAvailability
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class MypageUpdateAvailabilityTest {
+
+    // ── isUpdateAvailableFromPlayApi
+
+    @Test
+    fun `Play API UPDATE_AVAILABLE이면 업데이트 필요`() {
+        assertTrue(
+            MypageViewModel.isUpdateAvailableFromPlayApi(UpdateAvailability.UPDATE_AVAILABLE)
+        )
+    }
+
+    @Test
+    fun `Play API UPDATE_NOT_AVAILABLE이면 업데이트 불필요`() {
+        assertFalse(
+            MypageViewModel.isUpdateAvailableFromPlayApi(UpdateAvailability.UPDATE_NOT_AVAILABLE)
+        )
+    }
+
+    @Test
+    fun `Play API UNKNOWN이면 업데이트 불필요`() {
+        assertFalse(
+            MypageViewModel.isUpdateAvailableFromPlayApi(UpdateAvailability.UNKNOWN)
+        )
+    }
+
+    @Test
+    fun `Play API 업데이트 진행 중이면 업데이트 불필요`() {
+        assertFalse(
+            MypageViewModel.isUpdateAvailableFromPlayApi(
+                UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
+            )
+        )
+    }
+
+    // ── isUpdateAvailableFromServer (폴백)
+
+    @Test
+    fun `서버 버전이 현재 버전보다 높으면 업데이트 필요`() {
+        assertTrue(
+            MypageViewModel.isUpdateAvailableFromServer(
+                serverVersion = "v1.3.44",
+                currentVersion = "1.3.43"
+            )
+        )
+    }
+
+    @Test
+    fun `서버 버전과 현재 버전이 같으면 업데이트 불필요`() {
+        assertFalse(
+            MypageViewModel.isUpdateAvailableFromServer(
+                serverVersion = "v1.3.43",
+                currentVersion = "1.3.43"
+            )
+        )
+    }
+
+    @Test
+    fun `서버 버전이 비어있으면 업데이트 불필요`() {
+        assertFalse(
+            MypageViewModel.isUpdateAvailableFromServer(
+                serverVersion = "",
+                currentVersion = "1.3.43"
+            )
+        )
+    }
+
+    @Test
+    fun `서버 버전에 v 접두사 없으면 업데이트 필요로 처리`() {
+        assertTrue(
+            MypageViewModel.isUpdateAvailableFromServer(
+                serverVersion = "1.3.44",
+                currentVersion = "1.3.43"
+            )
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ accompanistFlowlayout = "0.36.0"
 accompanistSystemuicontroller = "0.30.1"
 accompanistWebview = "0.24.13-rc"
 agp = "8.7.0"
+playAppUpdate = "2.1.0"
 firebaseBom = "33.10.0"
 flatbuffersJava = "2.0.6"
 flatbuffersJavaVersion = "24.3.25"
@@ -53,6 +54,7 @@ accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-
 accompanist-webview = { module = "com.google.accompanist:accompanist-webview", version.ref = "accompanistWebview" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
+app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "playAppUpdate" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #262 

## 📝작업 내용

- 마이페이지에서 앱 버전 업데이트 여부를 서버 응답 값과 비교하여 노출하고 있었으나, 서버에서 전달되는 버전 정보의 정확도가 낮아 Google In-App Update를 통해 최신 버전 여부를 확인하도록 수정


## PR 발행 전 체크 리스트

- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인
- [ ] 코드 린트 확인

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * MyPage에서 앱 업데이트 가능 여부를 표시하고 업데이트 버튼을 노출
  * Google Play와 서버를 통한 업데이트 자동 감지 로직 추가

* **테스트**
  * 업데이트 감지 동작을 검증하는 단위 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/16th-team6-Android/pull/265)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->